### PR TITLE
Async property access

### DIFF
--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -122,6 +122,22 @@ test('multi-thread', async () => {
 	// console.log('Multi-thread: ', results.length, endTime - startTime)
 	expect(results).toHaveLength(10)
 })
+
+test('properties', async () => {
+	let original = new House([], ['south'])
+
+	original._windows = ['west', 'south']
+	expect(original.getWindows('asdf')).toHaveLength(2)
+	expect(original.getRooms()).toHaveLength(1)
+
+	let threaded = await threadedClass<House>('./classes/house.js', House, [[], ['south']])
+
+	await (threaded._windows = ['west', 'south'])
+	expect(await threaded.getWindows('asdf')).toHaveLength(2)
+	expect(await threaded.getRooms()).toHaveLength(1)
+
+	threaded._destroyChild()
+})
 // TODO: support this:
 // class House2 {
 

--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -132,7 +132,7 @@ test('properties', async () => {
 
 	let threaded = await threadedClass<House>('./classes/house.js', House, [[], ['south']])
 
-	await (threaded._windows = ['west', 'south'])
+	threaded._windows = ['west', 'south']
 	expect(await threaded.getWindows('asdf')).toHaveLength(2)
 	expect(await threaded.getRooms()).toHaveLength(1)
 

--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -62,7 +62,7 @@ test('import library class', async () => {
 		host: '192.168.0.1',
 		autoConnect: false
 	}])
-	expect(await threaded.host()).toEqual('192.168.0.1')
+	expect(await threaded.host).toEqual('192.168.0.1')
 
 	threaded._destroyChild()
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,7 @@ export function threadedClass<T> (orgModule: string, orgClass: Function, constru
 								})
 							},
 							set: function (newVal) {
-								let fixedArgs = fixArgs([ newVal ])
+								let fixedArgs = fixArgs(newVal)
 
 								return new Promise((resolve, reject) => {
 									sendFcn({

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { InitProps, InitProp } from './worker'
 export type ReturnType<T> = T extends (...args: any[]) => infer R ? R : any
 
 export type Promisify<T> = {
-	[K in keyof T]: (...args: any[]) => Promise<ReturnType<T[K]>>
+	[K in keyof T]: T[K] extends Function ? (...args: any[]) => Promise<ReturnType<T[K]>> : T[K]
 }
 
 export interface IProxy {
@@ -163,30 +163,65 @@ export function threadedClass<T> (orgModule: string, orgClass: Function, constru
 				}
 				props.forEach((p: InitProp) => {
 					if (closed) throw Error('Child process has been closed')
-					// @ts-ignore proxy is a class
-					proxy[p.key] = (...args: any[]) => {
-						return new Promise((resolve, reject) => {
-							// go through arguments and serialize them:
-							let fixedArgs = args.map((arg) => {
-								if (arg instanceof Buffer) return {type: 'Buffer', value: arg.toString('hex')}
-								if (typeof arg === 'string') return {type: 'string', value: arg}
-								if (typeof arg === 'number') return {type: 'number', value: arg}
-								if (typeof arg === 'function') {
-									callbackId++
-									callbacks[callbackId + ''] = arg
-									return {type: 'function', value: callbackId + ''}
-								}
-								return {type: 'other', value: arg}
-							})
-
-							sendFcn({
-								fcn: p.key,
-								args: fixedArgs
-							}, (err, res) => {
-								if (err) reject(err)
-								else resolve(res)
-							})
+					const fixArgs = (...args: any[]) => {
+						return args.map((arg) => {
+							if (arg instanceof Buffer) return {type: 'Buffer', value: arg.toString('hex')}
+							if (typeof arg === 'string') return {type: 'string', value: arg}
+							if (typeof arg === 'number') return {type: 'number', value: arg}
+							if (typeof arg === 'function') {
+								callbackId++
+								callbacks[callbackId + ''] = arg
+								return {type: 'function', value: callbackId + ''}
+							}
+							return {type: 'other', value: arg}
 						})
+					}
+
+					// console.log(p)
+					if (p.type === 'value') {
+						Object.defineProperty(proxy, p.key, {
+							get: function () {
+								return new Promise((resolve, reject) => {
+									sendFcn({
+										fcn: p.key,
+										args: []
+									}, (err, res) => {
+										if (err) reject(err)
+										else resolve(res)
+									})
+								})
+							},
+							set: function (newVal) {
+								let fixedArgs = fixArgs([ newVal ])
+
+								return new Promise((resolve, reject) => {
+									sendFcn({
+										fcn: p.key,
+										args: fixedArgs
+									}, (err, res) => {
+										if (err) reject(err)
+										else resolve(res)
+									})
+								})
+							},
+							configurable: true
+						})
+					} else {
+						// @ts-ignore proxy is a class
+						proxy[p.key] = (...args: any[]) => {
+							return new Promise((resolve, reject) => {
+								// go through arguments and serialize them:
+								let fixedArgs = fixArgs(...args)
+
+								sendFcn({
+									fcn: p.key,
+									args: fixedArgs
+								}, (err, res) => {
+									if (err) reject(err)
+									else resolve(res)
+								})
+							})
+						}
 					}
 				})
 				resolve(proxy)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -106,6 +106,9 @@ if (process.send) {
 						instance[msg.fcn](...fixedArgs) :
 						instance[msg.fcn]
 					)
+					if (typeof instance[msg.fcn] !== 'function' && fixedArgs.length === 1) {
+						instance[msg.fcn] = fixedArgs[0]
+					}
 					Promise.resolve(p)
 					.then((result) => {
 						reply(msg, result)


### PR DESCRIPTION
This PR adds property access. An update to the typings was made to make property access behave like actual (but asynchronous) properties. There is now the possibility to set properties.

```typescript
class House {
    windows = 0

    setWindows (num: number) {
        this.windows = num
    }
}

const normal = new House()
normal.setWindows(3)
normal.windows = 5
console.log(normal.windows)

const threadedOld = threadedClass<House>('./house', House, [])
await threadedOld.setWindows(3)
await threadedOld.windows(5) // this doesn't do anything
console.log(await threadedOld.windows()) // this at least works, but looks as if it is a function

const threadedNew = threadedClass<House>('./house', House, [])
await threadedNew.setWindows(3)
threadedNew.windows = 5
console.log(await threadedNew.windows)
```