### PR TITLE
fix: falsy values

### DIFF
--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -253,7 +253,7 @@ const getTests = (disableMultithreading: boolean) => {
 			//
 			// @ts-ignore this technically works, though the typings do not:
 			threaded.writeonly = 13
-			await expect(threaded.writeonly).rejects.toMatch(/not found/i) // Function "writeonly" not found
+			expect(await threaded.writeonly).toEqual(undefined)
 
 			await ThreadedClassManager.destroy(threaded)
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)


### PR DESCRIPTION
Falsy values should have the same falsy value on the consumer side as they do inside the class. Even if it's technically not a property of the class, it is expected to have the value `undefined`.