### PR TITLE
Develop

### DIFF
--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -10,6 +10,7 @@ import { TestClass } from '../../test-lib/testClass'
 
 const HOUSE_PATH = '../../test-lib/house.js'
 const TESTCLASS_PATH = '../../test-lib/testClass.js'
+const TESTCLASS_PATH_UNSYNCED = '../../test-lib/testClass-unsynced.js'
 
 // function wait (time: number) {
 // 	return new Promise((resolve) => {
@@ -540,6 +541,20 @@ const getTests = (disableMultithreading: boolean) => {
 			let self = await threaded.getSelf()
 
 			expect(self).toEqual(threaded)
+
+		})
+		test('import typescript', async () => {
+			let threaded 	= await threadedClass<TestClass>(TESTCLASS_PATH_UNSYNCED, TestClass, [], { disableMultithreading })
+
+			let id = await threaded.getId()
+
+			if (disableMultithreading) {
+				// expect the ts file to have been loaded:
+				expect(id).toEqual('abc')
+			} else {
+				// expect the js file to have been loaded:
+				expect(id).toEqual('unsynced')
+			}
 
 		})
 	}

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -90,6 +90,7 @@ export interface ChildInstance {
 	readonly onMessageCallback: (instance: ChildInstance, message: MessageFromChild) => void
 	readonly pathToModule: string
 	readonly className: string
+	readonly classFunction: Function // used in single-threaded mode
 	readonly constructorArgs: any[]
 	readonly config: ThreadedClassConfig
 	initialized: boolean
@@ -157,11 +158,12 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 		proxy: ThreadedClass<any>,
 		pathToModule: string,
 		className: string,
+		classFunction: Function,
 		constructorArgs: any[],
 		onMessage: (instance: ChildInstance, message: MessageFromChild) => void
 	): ChildInstance {
-
 		const instance: ChildInstance = {
+
 			id: 'instance_' + this._instanceId++,
 			child: child,
 			proxy: proxy,
@@ -170,6 +172,7 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 			onMessageCallback: onMessage,
 			pathToModule: pathToModule,
 			className: className,
+			classFunction: classFunction,
 			constructorArgs: constructorArgs,
 			initialized: false,
 			config: config
@@ -372,6 +375,7 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 			cmd: MessageType.INIT,
 			modulePath: instance.pathToModule,
 			className: instance.className,
+			classFunction: (config.disableMultithreading ? instance.classFunction : undefined),
 			args: instance.constructorArgs,
 			config: config
 		}

--- a/src/threadedClass.ts
+++ b/src/threadedClass.ts
@@ -184,6 +184,7 @@ export function threadedClass<T> (
 				proxy,
 				pathToModule,
 				orgClassName,
+				orgClass,
 				constructorArgs,
 				onMessage
 			)

--- a/test-lib/testClass-unsynced.js
+++ b/test-lib/testClass-unsynced.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const events_1 = require("events");
+class TestClass extends events_1.EventEmitter {
+    constructor() {
+        super();
+    }
+    getId() {
+		return 'unsynced'
+	}
+}
+exports.TestClass = TestClass;

--- a/test-lib/testClass.js
+++ b/test-lib/testClass.js
@@ -8,6 +8,9 @@ class TestClass extends events_1.EventEmitter {
         this.myself = this;
         this.myself = this.myself;
     }
+    getId() {
+        return 'abc';
+    }
     returnValue(value) {
         return value;
     }

--- a/test-lib/testClass.ts
+++ b/test-lib/testClass.ts
@@ -11,7 +11,9 @@ export class TestClass extends EventEmitter {
 		this.myself = this
 		this.myself = this.myself
 	}
-
+	public getId (): string {
+		return 'abc'
+	}
 	public returnValue<T> (value: T): T {
 		return value
 	}


### PR DESCRIPTION
feature: Enable direct import of class, when in single thread mode (not going via importing the js-file).

This allows for the correct classes to be run when running for example with ts-node (or when running tests).