### PR TITLE
Callbacks in class must be promises

### DIFF
--- a/src/__tests__/event.spec.ts
+++ b/src/__tests__/event.spec.ts
@@ -1,0 +1,93 @@
+import { threadedClass, ThreadedClassManager } from '..'
+// import { EventEmitter } from 'events'
+
+describe('EventEmitter', () => {
+	beforeEach(async () => {
+		await ThreadedClassManager.destroyAll()
+		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+	})
+	afterEach(async () => {
+		await ThreadedClassManager.destroyAll()
+		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+	})
+
+	// test('non-threadedclass emit', () => {
+	// 	const em = new EventEmitter()
+	// 	em.on('test', () => {
+	// 		throw new Error('abc')
+	// 	})
+
+	// 	try {
+	// 		em.emit('test')
+	// 	} catch (e) {
+	// 		// Finish here
+	// 		return
+	// 	}
+	// 	// Should end in the catch
+	// 	expect(false).toBeTruthy()
+	// })
+	// test('threadedclass emit', async () => {
+	// 	// class EventEmitterExt extends EventEmitter {
+	// 	// 	doEmit (str: string) {
+	// 	// 		this.emit(str)
+	// 	// 	}
+	// 	// }
+	// 	const em2 = await threadedClass<EventEmitter>('./nope.js', EventEmitter, [], {
+	// 		disableMultithreading: true
+	// 	})
+	// 	console.log('init')
+
+	// 	await em2.on('nope', console.log)
+
+	// 	await em2.on('test', (a: any, b: any) => {
+	// 		console.log('on', a, b)
+	// 		throw new Error('abc')
+	// 	})
+
+	// 	console.log('register')
+
+	// 	try {
+	// 		await em2.emit('test', 1, 5)
+	// 	} catch (e) {
+	// 		// Finish here
+	// 		return
+	// 	}
+	// 	// Should end in the catch
+	// 	expect(false).toBeTruthy()
+	// })
+
+	class FakeClass {
+		basicFcn (cb: () => number) {
+			// An example function that is not aware it might want to be run in a threadedClass
+			return cb() + 5
+		}
+
+		async promiseFcn (cb: () => Promise<number>) {
+			// This function is safe for threaded class, as its callback returns a promise
+			return await cb() + 5
+		}
+	}
+
+	test('class promise-callback', async () => {
+		const em2 = await threadedClass<FakeClass>('../../test-lib/house.js', FakeClass, [], {
+			disableMultithreading: true
+		})
+
+		const callback = () => 10
+
+		const res = await em2.promiseFcn(callback)
+		expect(res).toEqual(15)
+	})
+	test('class normal-callback', async () => {
+		const em2 = await threadedClass<FakeClass>('../../test-lib/house.js', FakeClass, [], {
+			disableMultithreading: true
+		})
+
+		const callback = () => 10
+
+		const res = await em2.basicFcn(callback)
+		expect(res).toEqual(15)
+	})
+
+
+})


### PR DESCRIPTION
@nytamin you are going to love this 'fun' case that I've spent quite a few hours today digging into today.

Essentially, as it is right now, any callback passed into a ThreadedClass gets slightly mangled, so that it returns a promise.
If the class does not define in its interface that the callback should return a promise, this will lead to weird type issues, as it will be getting a promise anyway. eg testcase `class normal-callback` gets back a value of `"[object Promise]5"` instead of the expected `15`.

This becomes quite a problem when the class is an EventEmitter, as it means that when the the parent does an `.on` on the threadedClass, if it throws an error in the callback provided to `.on`, then that error gets lost as an UnhandledPromiseRejection.
The expected behaviour here is for the error to get bubbled back to the emit.

I'm not sure how a solution to this will work. Somehow the callbacks passed in need to block the thread execution (fibers?)