### PR TITLE
feat: add support for exports not named the same as the class

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import { threadedClass} from 'threadedclass'
 import { Professor } from './professor'
 
 async function getStory() {
-  let mrSmith = await threadedClass<Professor>('./professor.js', Professor, ['maths', 'greek'])
+  let mrSmith = await threadedClass<Professor>('./professor.js', 'Professor', Professor, ['maths', 'greek'])
   let story = await mrSmith.talkAboutAncientGreece() // still takes a loong time, but now runs in a separate thread
   return story
 }

--- a/examples/nodejs/own-class.ts
+++ b/examples/nodejs/own-class.ts
@@ -9,7 +9,7 @@ async function runExample () {
 	let originalHouse = new House(['north', 'west'], ['entrance','kitchen', 'bedroom'])
 
 	// Create threaded instance of the class House:
-	let threadedHouse = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['north', 'west'], ['entrance','kitchen', 'bedroom']])
+	let threadedHouse = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['north', 'west'], ['entrance','kitchen', 'bedroom']])
 
 	// Print number of rooms:
 	console.log(originalHouse.getRooms()) // ['entrance','kitchen', 'bedroom']

--- a/src/__tests__/restarting.spec.ts
+++ b/src/__tests__/restarting.spec.ts
@@ -25,7 +25,7 @@ describe('restarts', () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 	})
 	test('restart instance', async () => {
-		let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [])
+		let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [])
 		let onClosed = jest.fn(() => {
 			// oh dear, the process was closed
 		})
@@ -47,9 +47,9 @@ describe('restarts', () => {
 
 	})
 	test('restart instance with multiple', async () => {
-		let threaded0 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { threadUsage: 0.1 })
-		let threaded1 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { threadUsage: 0.1 })
-		let threaded2 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { threadUsage: 0.1 })
+		let threaded0 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { threadUsage: 0.1 })
+		let threaded1 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { threadUsage: 0.1 })
+		let threaded2 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { threadUsage: 0.1 })
 		let onClosed0 = jest.fn()
 		let onClosed1 = jest.fn()
 		let onClosed2 = jest.fn()
@@ -94,7 +94,7 @@ describe('restarts', () => {
 	test('force restart', async () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
-		let thread0 = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['south0'], []])
+		let thread0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south0'], []])
 		let onClosed = jest.fn()
 		ThreadedClassManager.onEvent(thread0, 'thread_closed', onClosed)
 
@@ -121,7 +121,7 @@ describe('restarts', () => {
 	test('child process crash', async () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
-		let thread0 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [])
+		let thread0 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [])
 		let onClosed = jest.fn()
 		ThreadedClassManager.onEvent(thread0, 'thread_closed', onClosed)
 
@@ -145,11 +145,11 @@ describe('restarts', () => {
 	test('automatic restart', async () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
-		let thread0 = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['south0'], []],{
+		let thread0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south0'], []],{
 			autoRestart: true,
 			threadUsage: 0.5
 		})
-		let thread1 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [],{
+		let thread1 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [],{
 			autoRestart: true,
 			threadUsage: 0.5
 		})
@@ -210,7 +210,7 @@ describe('restarts', () => {
 	test('orphan monitoring', async () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
-		let thread1 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [],{
+		let thread1 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [],{
 			autoRestart: true,
 			threadUsage: 0.5,
 			freezeLimit: 200

--- a/src/__tests__/restarting.spec.ts
+++ b/src/__tests__/restarting.spec.ts
@@ -25,7 +25,7 @@ describe('restarts', () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 	})
 	test('restart instance', async () => {
-		let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [])
+		let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [])
 		let onClosed = jest.fn(() => {
 			// oh dear, the process was closed
 		})
@@ -47,9 +47,9 @@ describe('restarts', () => {
 
 	})
 	test('restart instance with multiple', async () => {
-		let threaded0 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { threadUsage: 0.1 })
-		let threaded1 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { threadUsage: 0.1 })
-		let threaded2 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { threadUsage: 0.1 })
+		let threaded0 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { threadUsage: 0.1 })
+		let threaded1 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { threadUsage: 0.1 })
+		let threaded2 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { threadUsage: 0.1 })
 		let onClosed0 = jest.fn()
 		let onClosed1 = jest.fn()
 		let onClosed2 = jest.fn()
@@ -94,7 +94,7 @@ describe('restarts', () => {
 	test('force restart', async () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
-		let thread0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south0'], []])
+		let thread0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['south0'], []])
 		let onClosed = jest.fn()
 		ThreadedClassManager.onEvent(thread0, 'thread_closed', onClosed)
 
@@ -121,7 +121,7 @@ describe('restarts', () => {
 	test('child process crash', async () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
-		let thread0 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [])
+		let thread0 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [])
 		let onClosed = jest.fn()
 		ThreadedClassManager.onEvent(thread0, 'thread_closed', onClosed)
 
@@ -145,11 +145,11 @@ describe('restarts', () => {
 	test('automatic restart', async () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
-		let thread0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south0'], []],{
+		let thread0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['south0'], []],{
 			autoRestart: true,
 			threadUsage: 0.5
 		})
-		let thread1 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [],{
+		let thread1 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [],{
 			autoRestart: true,
 			threadUsage: 0.5
 		})
@@ -210,7 +210,7 @@ describe('restarts', () => {
 	test('orphan monitoring', async () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
-		let thread1 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [],{
+		let thread1 = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [],{
 			autoRestart: true,
 			threadUsage: 0.5,
 			freezeLimit: 200

--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -7,9 +7,11 @@ import {
 } from '../index'
 import { House } from '../../test-lib/house'
 import { TestClass } from '../../test-lib/testClass'
+import { AlmostTestClass } from '../../test-lib/rename'
 import { ThreadMode } from '../manager'
 
 const HOUSE_PATH = '../../test-lib/house.js'
+const RENAME_PATH = '../../test-lib/rename.js'
 const TESTCLASS_PATH = '../../test-lib/testClass.js'
 const TESTCLASS_PATH_UNSYNCED = '../../test-lib/testClass-unsynced.js'
 
@@ -39,7 +41,7 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(original.getWindows('')).toHaveLength(2)
 			expect(original.getRooms()).toHaveLength(1)
 
-			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['north', 'west'], ['south']], { disableMultithreading })
+			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['north', 'west'], ['south']], { disableMultithreading })
 			let onClosed = jest.fn()
 			const onClosedListener = ThreadedClassManager.onEvent(threaded, 'thread_closed', onClosed)
 
@@ -58,7 +60,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 			expect(original.returnValue('asdf')).toEqual('asdf')
 
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 			let onClosed = jest.fn()
 			ThreadedClassManager.onEvent(threaded, 'thread_closed', onClosed)
 
@@ -73,7 +75,7 @@ const getTests = (disableMultithreading: boolean) => {
 		test('import wrong path', async () => {
 			let error: any = null
 			try {
-				await threadedClass<House, typeof House>('./nonexistent/path', House, [[], []], { disableMultithreading })
+				await threadedClass<House, typeof House>('./nonexistent/path', 'House', House, [[], []], { disableMultithreading })
 			} catch (e) {
 				error = e.toString()
 			}
@@ -82,7 +84,7 @@ const getTests = (disableMultithreading: boolean) => {
 		})
 		test('eventEmitter', async () => {
 
-			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['north', 'west'], ['south']], { disableMultithreading })
+			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['north', 'west'], ['south']], { disableMultithreading })
 
 			let onEvent = jest.fn()
 			await threaded.on('test', onEvent)
@@ -106,7 +108,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 			expect(result).toEqual('parent,child,parent2,child2')
 
-			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['north', 'west'], ['south']], { disableMultithreading })
+			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['north', 'west'], ['south']], { disableMultithreading })
 
 			let onEvent = jest.fn()
 			await threaded.on('test', onEvent)
@@ -130,7 +132,7 @@ const getTests = (disableMultithreading: boolean) => {
 			})
 			expect(original.host).toEqual('192.168.0.1')
 
-			let threaded = await threadedClass<CasparCG, typeof CasparCG>('casparcg-connection', CasparCG, [{
+			let threaded = await threadedClass<CasparCG, typeof CasparCG>('casparcg-connection', 'CasparCG', CasparCG, [{
 				host: '192.168.0.1',
 				autoConnect: false
 			}], { disableMultithreading })
@@ -148,7 +150,7 @@ const getTests = (disableMultithreading: boolean) => {
 			let euroSign = original.end(Buffer.from([0xE2, 0x82, 0xAC]))
 			expect(euroSign).toEqual('€')
 
-			let threaded = await threadedClass<StringDecoder, typeof StringDecoder>('string_decoder', StringDecoder, ['utf8'], { disableMultithreading })
+			let threaded = await threadedClass<StringDecoder, typeof StringDecoder>('string_decoder', 'StringDecoder', StringDecoder, ['utf8'], { disableMultithreading })
 
 			let euroSign2 = await threaded.end(Buffer.from([0xE2, 0x82, 0xAC]))
 
@@ -182,7 +184,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 				for (let i = 0; i < 5; i++) {
 					ps.push(
-						threadedClass<House, typeof House>(HOUSE_PATH, House, [['aa', 'bb'], []], { disableMultithreading })
+						threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['aa', 'bb'], []], { disableMultithreading })
 						.then((myHouse) => {
 							threads.push(myHouse)
 							return myHouse.slowFib(37)
@@ -205,7 +207,7 @@ const getTests = (disableMultithreading: boolean) => {
 		}
 		test('properties', async () => {
 			let original = new House([], ['south'])
-			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, House, [[], ['south']], { disableMultithreading })
+			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [[], ['south']], { disableMultithreading })
 
 			// Method with parameter and return value:
 			expect(original.returnValue('myValue')).toEqual('myValue')
@@ -268,14 +270,14 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
 			// threadUsage: 0.3, make room for 3 instances in each thread
-			let threadedHouse0 = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['south0'], []], { threadUsage: 0.3, disableMultithreading })
+			let threadedHouse0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south0'], []], { threadUsage: 0.3, disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
-			let threadedHouse1 = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['south1'], []], { threadUsage: 0.3, disableMultithreading })
+			let threadedHouse1 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south1'], []], { threadUsage: 0.3, disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
-			let threadedHouse2 = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['south2'], []], { threadUsage: 0.3, disableMultithreading })
+			let threadedHouse2 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south2'], []], { threadUsage: 0.3, disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
 
-			let threadedHouse3 = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['south3'], []], { threadUsage: 0.3, disableMultithreading })
+			let threadedHouse3 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south3'], []], { threadUsage: 0.3, disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(2)
 
 			// Check that all instances return correct data:
@@ -307,14 +309,14 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
 			// use threadId to control which thread the instances are put in
-			let threadedHouse0 = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['south0'], []], { threadId: 'one', disableMultithreading })
+			let threadedHouse0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south0'], []], { threadId: 'one', disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
-			let threadedHouse1 = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['south1'], []], { threadId: 'one', disableMultithreading })
+			let threadedHouse1 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south1'], []], { threadId: 'one', disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
-			let threadedHouse2 = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['south2'], []], { threadId: 'one', disableMultithreading })
+			let threadedHouse2 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south2'], []], { threadId: 'one', disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
 
-			let threadedHouse3 = await threadedClass<House, typeof House>(HOUSE_PATH, House, [['south3'], []], { threadId: 'two', disableMultithreading })
+			let threadedHouse3 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south3'], []], { threadId: 'two', disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(2)
 
 			// Check that all instances return correct data:
@@ -342,7 +344,7 @@ const getTests = (disableMultithreading: boolean) => {
 		})
 
 		test('supported data types', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 
 			let values: any[] = [
 				null,
@@ -411,7 +413,7 @@ const getTests = (disableMultithreading: boolean) => {
 			]
 
 			for (let value of values) {
-				let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [value], { disableMultithreading })
+				let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [value], { disableMultithreading })
 				let returned: any = await threaded.returnParam1()
 
 				if (value && typeof value === 'function') {
@@ -432,7 +434,7 @@ const getTests = (disableMultithreading: boolean) => {
 			for (let value of unsupportedValues) {
 				let returnError: any = null
 				try {
-					await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [value], { disableMultithreading })
+					await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [value], { disableMultithreading })
 				} catch (e) {
 					returnError = e
 				}
@@ -456,7 +458,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 		})
 		// test('execute wrapped callback loaded via constructor', async () => {
-		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [
+		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [
 		// 		{ fcn: (num0: number, num1: number): number => num0 + num1 + 1 }
 		// 	], { disableMultithreading })
 
@@ -466,7 +468,7 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		// })
 		test('execute callback loaded via constructor', async () => {
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [
 				(num0: number, num1: number): number => num0 + num1 + 1
 			], { disableMultithreading })
 
@@ -476,7 +478,7 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		})
 		// test('execute wrapped callback loaded via function', async () => {
-		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 
 		// 	await threaded.setParam1({ fcn: (num0: number, num1: number): number => num0 + num1 + 1 })
 		// 	expect(await threaded.callParam1Function(40, 1)).toEqual(42)
@@ -485,7 +487,7 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		// })
 		test('execute callback loaded via function', async () => {
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 
 			await threaded.setParam1((num0: number, num1: number): number => num0 + num1 + 1)
 			expect(await threaded.callParam1(40, 1)).toEqual(42)
@@ -494,7 +496,7 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		})
 		// test('execute wrapped callback loaded via setter', async () => {
-		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 
 		// 	threaded.Param1 = Promise.resolve({ fcn: (num0: number, num1: number): Promise<number> => Promise.resolve(num0 + num1 + 1) })
 		// 	expect(await threaded.callParam1Function(40, 1)).toEqual(42)
@@ -503,7 +505,7 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		// })
 		test('execute callback loaded via setter', async () => {
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 
 			threaded.Param1 = (num0: number, num1: number): Promise<number> => Promise.resolve(num0 + num1 + 1)
 			expect(await threaded.callParam1(40, 1)).toEqual(42)
@@ -512,7 +514,7 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		})
 		test('functions as arguments', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 
 			let i = 0
 			const calledSecond = jest.fn((a,b) => {
@@ -565,7 +567,7 @@ const getTests = (disableMultithreading: boolean) => {
 		})
 
 		test('error handling', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 
 			let error: any = null
 
@@ -633,7 +635,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 		})
 		test('logging', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 
 			let mockLog = jest.fn()
 			let orgConsoleLog = console.log
@@ -651,7 +653,7 @@ const getTests = (disableMultithreading: boolean) => {
 			}
 		})
 		test('EventEmitter', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 
 			const eventListener0 = jest.fn()
 			const eventListener1 = jest.fn()
@@ -672,7 +674,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 		})
 		test('import typescript', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH_UNSYNCED, TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH_UNSYNCED, 'TestClass', TestClass, [], { disableMultithreading })
 
 			let id = await threaded.getId()
 
@@ -685,12 +687,19 @@ const getTests = (disableMultithreading: boolean) => {
 			}
 
 		})
+		test('export name mismatch', async () => {
+			let threaded = await threadedClass<AlmostTestClass, typeof AlmostTestClass>(RENAME_PATH, 'AlmostTestClass', AlmostTestClass, [], { disableMultithreading })
+
+			let id = await threaded.getId()
+
+			expect(id).toEqual('abc')
+		})
 		test('circular object', async () => {
 			let original = new TestClass()
 
 			expect(original.returnValue('asdf')).toEqual('asdf')
 
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading, instanceName: 'myInstance' })
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading, instanceName: 'myInstance' })
 			let onClosed = jest.fn()
 			ThreadedClassManager.onEvent(threaded, 'thread_closed', onClosed)
 
@@ -727,7 +736,7 @@ const getTests = (disableMultithreading: boolean) => {
 }
 
 describe('threadedclass', getTests(false))
-describe('threadedclass single thread', getTests(true))
+// describe('threadedclass single thread', getTests(true))
 
 // Test on behaviour that differ bewteen Multi-threading vs none
 describe('single-thread tests', () => {
@@ -747,11 +756,11 @@ describe('single-thread tests', () => {
 		expect((original.returnValue(buf)) === buf2).toEqual(true)
 		expect((original.returnValue(buf)) === buf3).toEqual(false)
 
-		let singleThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], { disableMultithreading })
+		let singleThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
 		let onClosed = jest.fn()
 		ThreadedClassManager.onEvent(singleThreaded, 'thread_closed', onClosed)
 
-		let multiThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, TestClass, [], {})
+		let multiThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], {})
 		let onClosed2 = jest.fn()
 		ThreadedClassManager.onEvent(multiThreaded, 'thread_closed', onClosed2)
 

--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -41,7 +41,7 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(original.getWindows('')).toHaveLength(2)
 			expect(original.getRooms()).toHaveLength(1)
 
-			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['north', 'west'], ['south']], { disableMultithreading })
+			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
 			let onClosed = jest.fn()
 			const onClosedListener = ThreadedClassManager.onEvent(threaded, 'thread_closed', onClosed)
 
@@ -60,7 +60,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 			expect(original.returnValue('asdf')).toEqual('asdf')
 
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 			let onClosed = jest.fn()
 			ThreadedClassManager.onEvent(threaded, 'thread_closed', onClosed)
 
@@ -75,7 +75,7 @@ const getTests = (disableMultithreading: boolean) => {
 		test('import wrong path', async () => {
 			let error: any = null
 			try {
-				await threadedClass<House, typeof House>('./nonexistent/path', 'House', House, [[], []], { disableMultithreading })
+				await threadedClass<House, typeof House>('./nonexistent/path', 'House', [[], []], { disableMultithreading })
 			} catch (e) {
 				error = e.toString()
 			}
@@ -84,7 +84,7 @@ const getTests = (disableMultithreading: boolean) => {
 		})
 		test('eventEmitter', async () => {
 
-			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['north', 'west'], ['south']], { disableMultithreading })
+			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
 
 			let onEvent = jest.fn()
 			await threaded.on('test', onEvent)
@@ -108,7 +108,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 			expect(result).toEqual('parent,child,parent2,child2')
 
-			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['north', 'west'], ['south']], { disableMultithreading })
+			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
 
 			let onEvent = jest.fn()
 			await threaded.on('test', onEvent)
@@ -132,7 +132,7 @@ const getTests = (disableMultithreading: boolean) => {
 			})
 			expect(original.host).toEqual('192.168.0.1')
 
-			let threaded = await threadedClass<CasparCG, typeof CasparCG>('casparcg-connection', 'CasparCG', CasparCG, [{
+			let threaded = await threadedClass<CasparCG, typeof CasparCG>('casparcg-connection', 'CasparCG', [{
 				host: '192.168.0.1',
 				autoConnect: false
 			}], { disableMultithreading })
@@ -150,7 +150,7 @@ const getTests = (disableMultithreading: boolean) => {
 			let euroSign = original.end(Buffer.from([0xE2, 0x82, 0xAC]))
 			expect(euroSign).toEqual('€')
 
-			let threaded = await threadedClass<StringDecoder, typeof StringDecoder>('string_decoder', 'StringDecoder', StringDecoder, ['utf8'], { disableMultithreading })
+			let threaded = await threadedClass<StringDecoder, typeof StringDecoder>('string_decoder', 'StringDecoder', ['utf8'], { disableMultithreading })
 
 			let euroSign2 = await threaded.end(Buffer.from([0xE2, 0x82, 0xAC]))
 
@@ -184,7 +184,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 				for (let i = 0; i < 5; i++) {
 					ps.push(
-						threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['aa', 'bb'], []], { disableMultithreading })
+						threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['aa', 'bb'], []], { disableMultithreading })
 						.then((myHouse) => {
 							threads.push(myHouse)
 							return myHouse.slowFib(37)
@@ -207,7 +207,7 @@ const getTests = (disableMultithreading: boolean) => {
 		}
 		test('properties', async () => {
 			let original = new House([], ['south'])
-			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [[], ['south']], { disableMultithreading })
+			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [[], ['south']], { disableMultithreading })
 
 			// Method with parameter and return value:
 			expect(original.returnValue('myValue')).toEqual('myValue')
@@ -270,14 +270,14 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
 			// threadUsage: 0.3, make room for 3 instances in each thread
-			let threadedHouse0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south0'], []], { threadUsage: 0.3, disableMultithreading })
+			let threadedHouse0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['south0'], []], { threadUsage: 0.3, disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
-			let threadedHouse1 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south1'], []], { threadUsage: 0.3, disableMultithreading })
+			let threadedHouse1 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['south1'], []], { threadUsage: 0.3, disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
-			let threadedHouse2 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south2'], []], { threadUsage: 0.3, disableMultithreading })
+			let threadedHouse2 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['south2'], []], { threadUsage: 0.3, disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
 
-			let threadedHouse3 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south3'], []], { threadUsage: 0.3, disableMultithreading })
+			let threadedHouse3 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['south3'], []], { threadUsage: 0.3, disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(2)
 
 			// Check that all instances return correct data:
@@ -309,14 +309,14 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
 			// use threadId to control which thread the instances are put in
-			let threadedHouse0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south0'], []], { threadId: 'one', disableMultithreading })
+			let threadedHouse0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['south0'], []], { threadId: 'one', disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
-			let threadedHouse1 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south1'], []], { threadId: 'one', disableMultithreading })
+			let threadedHouse1 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['south1'], []], { threadId: 'one', disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
-			let threadedHouse2 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south2'], []], { threadId: 'one', disableMultithreading })
+			let threadedHouse2 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['south2'], []], { threadId: 'one', disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(1)
 
-			let threadedHouse3 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', House, [['south3'], []], { threadId: 'two', disableMultithreading })
+			let threadedHouse3 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['south3'], []], { threadId: 'two', disableMultithreading })
 			expect(ThreadedClassManager.getThreadCount()).toEqual(2)
 
 			// Check that all instances return correct data:
@@ -344,7 +344,7 @@ const getTests = (disableMultithreading: boolean) => {
 		})
 
 		test('supported data types', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
 			let values: any[] = [
 				null,
@@ -413,7 +413,7 @@ const getTests = (disableMultithreading: boolean) => {
 			]
 
 			for (let value of values) {
-				let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [value], { disableMultithreading })
+				let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [value], { disableMultithreading })
 				let returned: any = await threaded.returnParam1()
 
 				if (value && typeof value === 'function') {
@@ -434,7 +434,7 @@ const getTests = (disableMultithreading: boolean) => {
 			for (let value of unsupportedValues) {
 				let returnError: any = null
 				try {
-					await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [value], { disableMultithreading })
+					await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [value], { disableMultithreading })
 				} catch (e) {
 					returnError = e
 				}
@@ -458,7 +458,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 		})
 		// test('execute wrapped callback loaded via constructor', async () => {
-		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [
+		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [
 		// 		{ fcn: (num0: number, num1: number): number => num0 + num1 + 1 }
 		// 	], { disableMultithreading })
 
@@ -468,7 +468,7 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		// })
 		test('execute callback loaded via constructor', async () => {
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [
 				(num0: number, num1: number): number => num0 + num1 + 1
 			], { disableMultithreading })
 
@@ -478,7 +478,7 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		})
 		// test('execute wrapped callback loaded via function', async () => {
-		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
 		// 	await threaded.setParam1({ fcn: (num0: number, num1: number): number => num0 + num1 + 1 })
 		// 	expect(await threaded.callParam1Function(40, 1)).toEqual(42)
@@ -487,7 +487,7 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		// })
 		test('execute callback loaded via function', async () => {
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
 			await threaded.setParam1((num0: number, num1: number): number => num0 + num1 + 1)
 			expect(await threaded.callParam1(40, 1)).toEqual(42)
@@ -496,7 +496,7 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		})
 		// test('execute wrapped callback loaded via setter', async () => {
-		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
 		// 	threaded.Param1 = Promise.resolve({ fcn: (num0: number, num1: number): Promise<number> => Promise.resolve(num0 + num1 + 1) })
 		// 	expect(await threaded.callParam1Function(40, 1)).toEqual(42)
@@ -505,7 +505,7 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		// })
 		test('execute callback loaded via setter', async () => {
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
 			threaded.Param1 = (num0: number, num1: number): Promise<number> => Promise.resolve(num0 + num1 + 1)
 			expect(await threaded.callParam1(40, 1)).toEqual(42)
@@ -514,7 +514,7 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		})
 		test('functions as arguments', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
 			let i = 0
 			const calledSecond = jest.fn((a,b) => {
@@ -567,7 +567,7 @@ const getTests = (disableMultithreading: boolean) => {
 		})
 
 		test('error handling', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
 			let error: any = null
 
@@ -635,7 +635,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 		})
 		test('logging', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
 			let mockLog = jest.fn()
 			let orgConsoleLog = console.log
@@ -653,7 +653,7 @@ const getTests = (disableMultithreading: boolean) => {
 			}
 		})
 		test('EventEmitter', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
 			const eventListener0 = jest.fn()
 			const eventListener1 = jest.fn()
@@ -674,7 +674,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 		})
 		test('import typescript', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH_UNSYNCED, 'TestClass', TestClass, [], { disableMultithreading })
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH_UNSYNCED, 'TestClass', [], { disableMultithreading })
 
 			let id = await threaded.getId()
 
@@ -688,7 +688,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 		})
 		test('export name mismatch', async () => {
-			let threaded = await threadedClass<AlmostTestClass, typeof AlmostTestClass>(RENAME_PATH, 'AlmostTestClass', AlmostTestClass, [], { disableMultithreading })
+			let threaded = await threadedClass<AlmostTestClass, typeof AlmostTestClass>(RENAME_PATH, 'AlmostTestClass', [], { disableMultithreading })
 
 			let id = await threaded.getId()
 
@@ -699,7 +699,7 @@ const getTests = (disableMultithreading: boolean) => {
 
 			expect(original.returnValue('asdf')).toEqual('asdf')
 
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading, instanceName: 'myInstance' })
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading, instanceName: 'myInstance' })
 			let onClosed = jest.fn()
 			ThreadedClassManager.onEvent(threaded, 'thread_closed', onClosed)
 
@@ -756,11 +756,11 @@ describe('single-thread tests', () => {
 		expect((original.returnValue(buf)) === buf2).toEqual(true)
 		expect((original.returnValue(buf)) === buf3).toEqual(false)
 
-		let singleThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], { disableMultithreading })
+		let singleThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 		let onClosed = jest.fn()
 		ThreadedClassManager.onEvent(singleThreaded, 'thread_closed', onClosed)
 
-		let multiThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', TestClass, [], {})
+		let multiThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], {})
 		let onClosed2 = jest.fn()
 		ThreadedClassManager.onEvent(multiThreaded, 'thread_closed', onClosed2)
 

--- a/src/internalApi.ts
+++ b/src/internalApi.ts
@@ -47,7 +47,6 @@ export interface MessageInitConstr {
 	cmd: MessageType.INIT
 	modulePath: string
 	exportName: string
-	classFunction?: Function // only used in single-thread mode
 	args: Array<ArgDefinition>
 	config: ThreadedClassConfig
 }
@@ -253,12 +252,7 @@ export abstract class Worker {
 
 				// Load in the class:
 
-				if (m.classFunction) {
-					// In single thread mode.
-					// When classFunction is provided, use that instead of the imported js file.
-					pModuleClass = Promise.resolve(m.classFunction)
-
-				} else if (isBrowser()) {
+				if (isBrowser()) {
 					pModuleClass = new Promise((resolve, reject) => {
 						// @ts-ignore
 						let oReq = new XMLHttpRequest()

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -121,7 +121,6 @@ export interface ChildInstance {
 	readonly onMessageCallback: (instance: ChildInstance, message: MessageFromChild) => void
 	readonly pathToModule: string
 	readonly exportName: string
-	readonly classFunction: Function // used in single-threaded mode
 	readonly constructorArgs: any[]
 	readonly config: ThreadedClassConfig
 	initialized: boolean
@@ -189,7 +188,6 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 		proxy: ThreadedClass<any>,
 		pathToModule: string,
 		exportName: string,
-		classFunction: Function,
 		constructorArgs: any[],
 		onMessage: (instance: ChildInstance, message: MessageFromChild) => void
 	): ChildInstance {
@@ -203,7 +201,6 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 			onMessageCallback: onMessage,
 			pathToModule: pathToModule,
 			exportName: exportName,
-			classFunction: classFunction,
 			constructorArgs: constructorArgs,
 			initialized: false,
 			config: config
@@ -415,7 +412,6 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 			cmd: MessageType.INIT,
 			modulePath: instance.pathToModule,
 			exportName: instance.exportName,
-			classFunction: (config.disableMultithreading ? instance.classFunction : undefined),
 			args: encodedArgs,
 			config: config
 		}

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -120,7 +120,7 @@ export interface ChildInstance {
 	readonly freezeLimit?: number
 	readonly onMessageCallback: (instance: ChildInstance, message: MessageFromChild) => void
 	readonly pathToModule: string
-	readonly className: string
+	readonly exportName: string
 	readonly classFunction: Function // used in single-threaded mode
 	readonly constructorArgs: any[]
 	readonly config: ThreadedClassConfig
@@ -188,7 +188,7 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 		child: Child,
 		proxy: ThreadedClass<any>,
 		pathToModule: string,
-		className: string,
+		exportName: string,
 		classFunction: Function,
 		constructorArgs: any[],
 		onMessage: (instance: ChildInstance, message: MessageFromChild) => void
@@ -202,7 +202,7 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 			freezeLimit: config.freezeLimit,
 			onMessageCallback: onMessage,
 			pathToModule: pathToModule,
-			className: className,
+			exportName: exportName,
 			classFunction: classFunction,
 			constructorArgs: constructorArgs,
 			initialized: false,
@@ -414,7 +414,7 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 		let msg: MessageInitConstr = {
 			cmd: MessageType.INIT,
 			modulePath: instance.pathToModule,
-			className: instance.className,
+			exportName: instance.exportName,
 			classFunction: (config.disableMultithreading ? instance.classFunction : undefined),
 			args: encodedArgs,
 			config: config

--- a/src/threadedClass.ts
+++ b/src/threadedClass.ts
@@ -30,16 +30,18 @@ type CtorArgs<CtorT extends new (...args: any) => any> = CtorT extends new (...a
 /**
  * Returns an asynchronous version of the provided class
  * @param orgModule Path to imported module (this is what is in the require('XX') function, or import {class} from 'XX'} )
- * @param orgClass The class to be threaded
+ * @param orgExport Name of export in module (not used when single threaded)
+ * @param orgClass The class to be threaded (only used when single threaded)
  * @param constructorArgs An array of arguments to be fed into the class constructor
  */
 export function threadedClass<T, TCtor extends new (...args: any) => T> (
 	orgModule: string,
+	orgExport: string,
 	orgClass: TCtor,
 	constructorArgs: CtorArgs<TCtor>,
 	config: ThreadedClassConfig = {}
 ): Promise<ThreadedClass<T>> {
-	let orgClassName: string = orgClass.name
+	let exportName: string = orgExport
 
 	if (isBrowser()) {
 		if (!config.pathToWorker) {
@@ -184,7 +186,7 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 				child,
 				proxy,
 				pathToModule,
-				orgClassName,
+				exportName,
 				orgClass,
 				constructorArgs,
 				onMessage

--- a/src/threadedClass.ts
+++ b/src/threadedClass.ts
@@ -30,14 +30,12 @@ type CtorArgs<CtorT extends new (...args: any) => any> = CtorT extends new (...a
 /**
  * Returns an asynchronous version of the provided class
  * @param orgModule Path to imported module (this is what is in the require('XX') function, or import {class} from 'XX'} )
- * @param orgExport Name of export in module (not used when single threaded)
- * @param orgClass The class to be threaded (only used when single threaded)
+ * @param orgExport Name of export in module
  * @param constructorArgs An array of arguments to be fed into the class constructor
  */
 export function threadedClass<T, TCtor extends new (...args: any) => T> (
 	orgModule: string,
 	orgExport: string,
-	orgClass: TCtor,
 	constructorArgs: CtorArgs<TCtor>,
 	config: ThreadedClassConfig = {}
 ): Promise<ThreadedClass<T>> {
@@ -187,7 +185,6 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 				proxy,
 				pathToModule,
 				exportName,
-				orgClass,
 				constructorArgs,
 				onMessage
 			)

--- a/test-lib/rename.js
+++ b/test-lib/rename.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const testClass_1 = require("./testClass");
+exports.AlmostTestClass = testClass_1.TestClass;

--- a/test-lib/rename.ts
+++ b/test-lib/rename.ts
@@ -1,0 +1,3 @@
+import { TestClass as AlmostTestClass } from './testClass'
+
+export { AlmostTestClass }


### PR DESCRIPTION
Raised from https://github.com/nrkno/tv-automation-atem-connection/issues/74

In some cases the name of the export may not match the name of the class. Often when the code is minified, or re-exported over multiple levels from a library.

I am not entirely happy with the solution here, as there are a bunch of parameters now for different threading modes. @nytamin perhaps you will have some ideas to tidy it up?