### PR TITLE
Feat/strict class type

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@types/node": "^12.12.5",
     "@types/uuid": "^8.0.0",
     "browserify": "^16.5.1",
-    "casparcg-connection": "^3.0.1",
     "codecov": "^3.7.0",
     "gh-pages": "^3.0.0",
     "gulp": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/callsites": "^3.0.0",
     "@types/jest": "^25.2.3",
     "@types/node": "^12.12.5",
+    "@types/uuid": "^3.4.6",
     "browserify": "^16.5.1",
     "casparcg-connection": "^3.0.1",
     "codecov": "^3.7.0",
@@ -92,7 +93,7 @@
     "tslint": "^6.1.2",
     "tslint-config-standard": "^9.0.0",
     "typedoc": "^0.16.0",
-    "typescript": "~3.6.4",
+    "typescript": "~3.9.4",
     "uglify-js": "^3.6.0",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
@@ -105,8 +106,10 @@
   ],
   "dependencies": {
     "callsites": "^3.1.0",
+    "emittery": "^0.5.1",
     "eventemitter3": "^4.0.4",
-    "tslib": "^1.13.0"
+    "tslib": "^2.0.0",
+    "uuid": "^3.3.3"
   },
   "standard-version": {
     "message": "chore(release): %s [skip ci]",

--- a/package.json
+++ b/package.json
@@ -71,10 +71,9 @@
     "/LICENSE"
   ],
   "devDependencies": {
-    "@types/callsites": "^3.0.0",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^12.12.5",
-    "@types/uuid": "^3.4.6",
+    "@types/uuid": "^8.0.0",
     "browserify": "^16.5.1",
     "casparcg-connection": "^3.0.1",
     "codecov": "^3.7.0",
@@ -92,7 +91,7 @@
     "ts-jest": "^26.1.0",
     "tslint": "^6.1.2",
     "tslint-config-standard": "^9.0.0",
-    "typedoc": "^0.16.0",
+    "typedoc": "^0.17.7",
     "typescript": "~3.9.4",
     "uglify-js": "^3.6.0",
     "vinyl-buffer": "^1.0.1",
@@ -109,7 +108,7 @@
     "emittery": "^0.5.1",
     "eventemitter3": "^4.0.4",
     "tslib": "^2.0.0",
-    "uuid": "^3.3.3"
+    "uuid": "^8.1.0"
   },
   "standard-version": {
     "message": "chore(release): %s [skip ci]",

--- a/src/__tests__/event.spec.ts
+++ b/src/__tests__/event.spec.ts
@@ -1,4 +1,5 @@
 import { threadedClass, ThreadedClassManager } from '..'
+import { CallbackClass } from '../../test-lib/event'
 // import { EventEmitter } from 'events'
 
 describe('EventEmitter', () => {
@@ -56,38 +57,26 @@ describe('EventEmitter', () => {
 	// 	expect(false).toBeTruthy()
 	// })
 
-	class FakeClass {
-		basicFcn (cb: () => number) {
-			// An example function that is not aware it might want to be run in a threadedClass
-			return cb() + 5
-		}
-
-		async promiseFcn (cb: () => Promise<number>) {
-			// This function is safe for threaded class, as its callback returns a promise
-			return await cb() + 5
-		}
-	}
-
 	test('class promise-callback', async () => {
-		const em2 = await threadedClass<FakeClass>('../../test-lib/house.js', FakeClass, [], {
+		const em2 = await threadedClass<CallbackClass, typeof CallbackClass>('../../test-lib/event.js', 'CallbackClass', [], {
 			disableMultithreading: true
 		})
 
-		const callback = () => 10
+		const callback = async () => 10
 
 		const res = await em2.promiseFcn(callback)
 		expect(res).toEqual(15)
 	})
-	test('class normal-callback', async () => {
-		const em2 = await threadedClass<FakeClass>('../../test-lib/house.js', FakeClass, [], {
-			disableMultithreading: true
-		})
+	// test('class normal-callback', async () => {
+	// 	const em2 = await threadedClass<CallbackClass, typeof CallbackClass>('../../test-lib/event.js', 'CallbackClass', [], {
+	// 		disableMultithreading: true
+	// 	})
 
-		const callback = () => 10
+	// 	const callback = () => 10
 
-		const res = await em2.basicFcn(callback)
-		expect(res).toEqual(15)
-	})
+	// 	const res = await em2.basicFcn(callback)
+	// 	expect(res).toEqual(15)
+	// })
 
 
 })

--- a/src/__tests__/event.spec.ts
+++ b/src/__tests__/event.spec.ts
@@ -1,0 +1,93 @@
+import { threadedClass, ThreadedClassManager } from '..'
+// import { EventEmitter } from 'events'
+
+describe('EventEmitter', () => {
+	beforeEach(async () => {
+		await ThreadedClassManager.destroyAll()
+		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+	})
+	afterEach(async () => {
+		await ThreadedClassManager.destroyAll()
+		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+	})
+
+	// test('non-threadedclass emit', () => {
+	// 	const em = new EventEmitter()
+	// 	em.on('test', () => {
+	// 		throw new Error('abc')
+	// 	})
+
+	// 	try {
+	// 		em.emit('test')
+	// 	} catch (e) {
+	// 		// Finish here
+	// 		return
+	// 	}
+	// 	// Should end in the catch
+	// 	expect(false).toBeTruthy()
+	// })
+	// test('threadedclass emit', async () => {
+	// 	// class EventEmitterExt extends EventEmitter {
+	// 	// 	doEmit (str: string) {
+	// 	// 		this.emit(str)
+	// 	// 	}
+	// 	// }
+	// 	const em2 = await threadedClass<EventEmitter>('./nope.js', EventEmitter, [], {
+	// 		disableMultithreading: true
+	// 	})
+	// 	console.log('init')
+
+	// 	await em2.on('nope', console.log)
+
+	// 	await em2.on('test', (a: any, b: any) => {
+	// 		console.log('on', a, b)
+	// 		throw new Error('abc')
+	// 	})
+
+	// 	console.log('register')
+
+	// 	try {
+	// 		await em2.emit('test', 1, 5)
+	// 	} catch (e) {
+	// 		// Finish here
+	// 		return
+	// 	}
+	// 	// Should end in the catch
+	// 	expect(false).toBeTruthy()
+	// })
+
+	class FakeClass {
+		basicFcn (cb: () => number) {
+			// An example function that is not aware it might want to be run in a threadedClass
+			return cb() + 5
+		}
+
+		async promiseFcn (cb: () => Promise<number>) {
+			// This function is safe for threaded class, as its callback returns a promise
+			return await cb() + 5
+		}
+	}
+
+	test('class promise-callback', async () => {
+		const em2 = await threadedClass<FakeClass>('../../test-lib/house.js', FakeClass, [], {
+			disableMultithreading: true
+		})
+
+		const callback = () => 10
+
+		const res = await em2.promiseFcn(callback)
+		expect(res).toEqual(15)
+	})
+	test('class normal-callback', async () => {
+		const em2 = await threadedClass<FakeClass>('../../test-lib/house.js', FakeClass, [], {
+			disableMultithreading: true
+		})
+
+		const callback = () => 10
+
+		const res = await em2.basicFcn(callback)
+		expect(res).toEqual(15)
+	})
+
+
+})

--- a/src/__tests__/restarting.spec.ts
+++ b/src/__tests__/restarting.spec.ts
@@ -44,7 +44,6 @@ describe('restarts', () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
 		expect(onClosed).toHaveBeenCalledTimes(2)
-
 	})
 	test('restart instance with multiple', async () => {
 		let threaded0 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { threadUsage: 0.1 })
@@ -170,9 +169,9 @@ describe('restarts', () => {
 		expect(ThreadedClassManager.getThreadCount()).toEqual(1)
 
 		const p0 = thread1.waitReply(200, 'test2')
-		.catch(err => { throw err.toString() })
+		.catch((err: any) => { throw err.toString() })
 		const p1 = thread1.exitProcess(0) // will cause the child to crash
-		.catch(err => { throw err.toString() })
+		.catch((err: any) => { throw err.toString() })
 
 		await expect(p0).rejects.toMatch(/closed/i)
 		await expect(p1).rejects.toMatch(/closed/i)
@@ -191,9 +190,9 @@ describe('restarts', () => {
 		expect(await thread0.getWindows('')).toEqual(['south0']) // because the instance has been restarted, it is reset
 
 		const p2 = thread1.waitReply(200, 'test2')
-		.catch(err => { throw err.toString() })
+		.catch((err: any) => { throw err.toString() })
 		const p3 = thread1.freeze() // will cause the child to freeze
-		.catch(err => { throw err.toString() })
+		.catch((err: any) => { throw err.toString() })
 
 		await expect(p2).rejects.toMatch(/timeout/i)
 		await expect(p3).rejects.toMatch(/timeout/i)

--- a/src/__tests__/test-lib.spec.ts
+++ b/src/__tests__/test-lib.spec.ts
@@ -1,7 +1,7 @@
-// import { House as HouseTS } from '../../test-lib/house'
-// import { House as HouseJS } from '../../test-lib/house.js'
-// import { TestClass as TestClassTS } from '../../test-lib/testClass'
-// import { TestClass as TestClassJS } from '../../test-lib/testClass.js'
+import { House as HouseTS } from '../../test-lib/house'
+import { House as HouseJS } from '../../test-lib/house.js'
+import { TestClass as TestClassTS } from '../../test-lib/testClass'
+import { TestClass as TestClassJS } from '../../test-lib/testClass.js'
 
 describe('test-lib', () => {
 
@@ -18,93 +18,85 @@ describe('test-lib', () => {
 		process.exit = orgProcessExit
 	})
 	test('one', () => {})
-	// test('House', async () => {
-	// 	let houses = [
-	// 		new HouseTS(['window0', 'window1', 'window2'], ['room0', 'room1']),
-	// 		new HouseJS(['window0', 'window1', 'window2'], ['room0', 'room1'])
-	// 	]
-	// 	for (let house of houses) {
+	test('House', async () => {
+		let houses = [
+			new HouseTS(['window0', 'window1', 'window2'], ['room0', 'room1']),
+			new HouseJS(['window0', 'window1', 'window2'], ['room0', 'room1'])
+		]
+		for (let house of houses) {
 
-	// 		const onEvent = jest.fn()
-	// 		house.on('evt', onEvent)
+			const onEvent = jest.fn()
+			await house.on('evt', onEvent)
 
-	// 		expect(house.returnValue(12)).toEqual(12)
-	// 		expect(house.getWindows('aa')).toEqual(['aa', 'window0', 'window1', 'window2'])
-	// 		expect(house.getWindows('')).toEqual(['window0', 'window1', 'window2'])
-	// 		house.setWindows(['window0', 'window1'])
-	// 		expect(house.getWindows('bb')).toEqual(['bb', 'window0', 'window1'])
-	// 		expect(house.getRooms()).toEqual(['room0', 'room1'])
-	// 		expect(house.getterRooms).toEqual(['room0', 'room1'])
-	// 		house.lamps = 15
-	// 		expect(house.lamps).toEqual(15)
-	// 		expect(house.readonly).toEqual(42)
-	// 		house.writeonly = 32
-	// 		expect(house.slowFib(6)).toEqual(8)
+			expect(await house.returnValue(12)).toEqual(12)
+			expect(await house.getWindows('aa')).toEqual(['aa', 'window0', 'window1', 'window2'])
+			expect(await house.getWindows('')).toEqual(['window0', 'window1', 'window2'])
+			await house.setWindows(['window0', 'window1'])
+			expect(await house.getWindows('bb')).toEqual(['bb', 'window0', 'window1'])
+			expect(await house.getRooms()).toEqual(['room0', 'room1'])
+			expect(await house.slowFib(6)).toEqual(8)
 
-	// 		expect(onEvent).toHaveBeenCalledTimes(0)
-	// 		house.doEmit('evt')
-	// 		expect(onEvent).toHaveBeenCalledTimes(1)
-	// 		const cb = jest.fn((name: string) => {
-	// 			return Promise.resolve('cb' + name)
-	// 		})
-	// 		let result = await house.callCallback('a', cb)
-	// 		expect(cb).toHaveBeenCalledTimes(1)
-	// 		expect(result).toEqual('cba,child,child2')
+			expect(onEvent).toHaveBeenCalledTimes(0)
+			await house.doEmit('evt')
+			expect(onEvent).toHaveBeenCalledTimes(1)
+			const cb = jest.fn((name: string) => {
+				return Promise.resolve('cb' + name)
+			})
+			let result = await house.callCallback('a', cb)
+			expect(cb).toHaveBeenCalledTimes(1)
+			expect(result).toEqual('cba,child,child2')
 
-	// 		await expect(
-	// 			house.callCallback('a', (_name: string) => {
-	// 				return Promise.reject('nope')
-	// 			})
-	// 		).rejects.toMatch(/nope/)
+			await expect(
+				house.callCallback('a', (_name: string) => {
+					return Promise.reject('nope')
+				})
+			).rejects.toMatch(/nope/)
 
-	// 	}
+		}
 
-	// })
+	})
 
-	// test('TestClass', async () => {
-	// 	let testClasses = [
-	// 		new TestClassTS(),
-	// 		new TestClassJS()
-	// 	]
-	// 	for (let testClass of testClasses) {
-	// 		mockExit.mockClear()
+	test('TestClass', async () => {
+		let testClasses = [
+			new TestClassTS(),
+			new TestClassJS()
+		]
+		for (let testClass of testClasses) {
+			mockExit.mockClear()
 
-	// 		expect(testClass.returnValue('123')).toEqual('123')
-	// 		const cb = jest.fn((name: string, name2: string) => {
-	// 			return 'cb' + name + name2
-	// 		})
-	// 		expect(testClass.callFunction(cb, 'a', 'b')).toEqual('cbab')
-	// 		expect(() => {
-	// 			testClass.throwError()
-	// 		}).toThrowError()
-	// 		expect(() => {
-	// 			testClass.throwErrorString()
-	// 		}).toThrowError()
+			expect(await testClass.returnValue('123')).toEqual('123')
+			const cb = jest.fn((name: string, name2: string) => {
+				return Promise.resolve('cb' + name + name2)
+			})
+			expect(await testClass.callFunction(cb, 'a', 'b')).toEqual('cbab')
 
-	// 		testClass.exitProcess(0)
-	// 		expect(mockExit).toHaveBeenCalledTimes(1)
+			await expect(testClass.throwError()).rejects.toEqual(new Error('Error thrown'))
+			await expect(testClass.throwErrorString()).rejects.toEqual('Error string thrown')
 
-	// 		testClass.exitProcess(20)
-	// 		await wait(30)
-	// 		expect(mockExit).toHaveBeenCalledTimes(2)
+			await testClass.exitProcess(0)
+			expect(mockExit).toHaveBeenCalledTimes(1)
 
-	// 		let mockLog = jest.fn()
-	// 		let orgConsoleLog = console.log
-	// 		console.log = mockLog
+			await testClass.exitProcess(20)
+			await wait(30)
+			expect(mockExit).toHaveBeenCalledTimes(2)
 
-	// 		testClass.logSomething('aa', 'bb')
+			let mockLog = jest.fn()
+			let orgConsoleLog = console.log
+			console.log = mockLog
 
-	// 		console.log = orgConsoleLog
+			await testClass.logSomething('aa', 'bb')
 
-	// 		expect(mockLog).toHaveBeenCalledTimes(1)
-	// 		expect(mockLog.mock.calls[0]).toEqual(['aa', 'bb'])
+			console.log = orgConsoleLog
 
-	// 		expect(await testClass.waitReply(10, 'test11')).toEqual('test11')
-	// 	}
-	// })
-	// function wait (time: number) {
-	// 	return new Promise((resolve) => {
-	// 		setTimeout(resolve, time)
-	// 	})
-	// }
+			expect(mockLog).toHaveBeenCalledTimes(1)
+			expect(mockLog.mock.calls[0]).toEqual(['aa', 'bb'])
+
+			expect(await testClass.waitReply(10, 'test11')).toEqual('test11')
+		}
+	})
+	function wait (time: number) {
+		return new Promise((resolve) => {
+			setTimeout(resolve, time)
+		})
+	}
 })

--- a/src/__tests__/test-lib.spec.ts
+++ b/src/__tests__/test-lib.spec.ts
@@ -1,7 +1,7 @@
-import { House as HouseTS } from '../../test-lib/house'
-import { House as HouseJS } from '../../test-lib/house.js'
-import { TestClass as TestClassTS } from '../../test-lib/testClass'
-import { TestClass as TestClassJS } from '../../test-lib/testClass.js'
+// import { House as HouseTS } from '../../test-lib/house'
+// import { House as HouseJS } from '../../test-lib/house.js'
+// import { TestClass as TestClassTS } from '../../test-lib/testClass'
+// import { TestClass as TestClassJS } from '../../test-lib/testClass.js'
 
 describe('test-lib', () => {
 
@@ -17,93 +17,94 @@ describe('test-lib', () => {
 		// @ts-ignore
 		process.exit = orgProcessExit
 	})
-	test('House', async () => {
-		let houses = [
-			new HouseTS(['window0', 'window1', 'window2'], ['room0', 'room1']),
-			new HouseJS(['window0', 'window1', 'window2'], ['room0', 'room1'])
-		]
-		for (let house of houses) {
+	test('one', () => {})
+	// test('House', async () => {
+	// 	let houses = [
+	// 		new HouseTS(['window0', 'window1', 'window2'], ['room0', 'room1']),
+	// 		new HouseJS(['window0', 'window1', 'window2'], ['room0', 'room1'])
+	// 	]
+	// 	for (let house of houses) {
 
-			const onEvent = jest.fn()
-			house.on('evt', onEvent)
+	// 		const onEvent = jest.fn()
+	// 		house.on('evt', onEvent)
 
-			expect(house.returnValue(12)).toEqual(12)
-			expect(house.getWindows('aa')).toEqual(['aa', 'window0', 'window1', 'window2'])
-			expect(house.getWindows('')).toEqual(['window0', 'window1', 'window2'])
-			house.setWindows(['window0', 'window1'])
-			expect(house.getWindows('bb')).toEqual(['bb', 'window0', 'window1'])
-			expect(house.getRooms()).toEqual(['room0', 'room1'])
-			expect(house.getterRooms).toEqual(['room0', 'room1'])
-			house.lamps = 15
-			expect(house.lamps).toEqual(15)
-			expect(house.readonly).toEqual(42)
-			house.writeonly = 32
-			expect(house.slowFib(6)).toEqual(8)
+	// 		expect(house.returnValue(12)).toEqual(12)
+	// 		expect(house.getWindows('aa')).toEqual(['aa', 'window0', 'window1', 'window2'])
+	// 		expect(house.getWindows('')).toEqual(['window0', 'window1', 'window2'])
+	// 		house.setWindows(['window0', 'window1'])
+	// 		expect(house.getWindows('bb')).toEqual(['bb', 'window0', 'window1'])
+	// 		expect(house.getRooms()).toEqual(['room0', 'room1'])
+	// 		expect(house.getterRooms).toEqual(['room0', 'room1'])
+	// 		house.lamps = 15
+	// 		expect(house.lamps).toEqual(15)
+	// 		expect(house.readonly).toEqual(42)
+	// 		house.writeonly = 32
+	// 		expect(house.slowFib(6)).toEqual(8)
 
-			expect(onEvent).toHaveBeenCalledTimes(0)
-			house.doEmit('evt')
-			expect(onEvent).toHaveBeenCalledTimes(1)
-			const cb = jest.fn((name: string) => {
-				return Promise.resolve('cb' + name)
-			})
-			let result = await house.callCallback('a', cb)
-			expect(cb).toHaveBeenCalledTimes(1)
-			expect(result).toEqual('cba,child,child2')
+	// 		expect(onEvent).toHaveBeenCalledTimes(0)
+	// 		house.doEmit('evt')
+	// 		expect(onEvent).toHaveBeenCalledTimes(1)
+	// 		const cb = jest.fn((name: string) => {
+	// 			return Promise.resolve('cb' + name)
+	// 		})
+	// 		let result = await house.callCallback('a', cb)
+	// 		expect(cb).toHaveBeenCalledTimes(1)
+	// 		expect(result).toEqual('cba,child,child2')
 
-			await expect(
-				house.callCallback('a', (_name: string) => {
-					return Promise.reject('nope')
-				})
-			).rejects.toMatch(/nope/)
+	// 		await expect(
+	// 			house.callCallback('a', (_name: string) => {
+	// 				return Promise.reject('nope')
+	// 			})
+	// 		).rejects.toMatch(/nope/)
 
-		}
+	// 	}
 
-	})
+	// })
 
-	test('TestClass', async () => {
-		let testClasses = [
-			new TestClassTS(),
-			new TestClassJS()
-		]
-		for (let testClass of testClasses) {
-			mockExit.mockClear()
+	// test('TestClass', async () => {
+	// 	let testClasses = [
+	// 		new TestClassTS(),
+	// 		new TestClassJS()
+	// 	]
+	// 	for (let testClass of testClasses) {
+	// 		mockExit.mockClear()
 
-			expect(testClass.returnValue('123')).toEqual('123')
-			const cb = jest.fn((name: string, name2: string) => {
-				return 'cb' + name + name2
-			})
-			expect(testClass.callFunction(cb, 'a', 'b')).toEqual('cbab')
-			expect(() => {
-				testClass.throwError()
-			}).toThrowError()
-			expect(() => {
-				testClass.throwErrorString()
-			}).toThrowError()
+	// 		expect(testClass.returnValue('123')).toEqual('123')
+	// 		const cb = jest.fn((name: string, name2: string) => {
+	// 			return 'cb' + name + name2
+	// 		})
+	// 		expect(testClass.callFunction(cb, 'a', 'b')).toEqual('cbab')
+	// 		expect(() => {
+	// 			testClass.throwError()
+	// 		}).toThrowError()
+	// 		expect(() => {
+	// 			testClass.throwErrorString()
+	// 		}).toThrowError()
 
-			testClass.exitProcess(0)
-			expect(mockExit).toHaveBeenCalledTimes(1)
+	// 		testClass.exitProcess(0)
+	// 		expect(mockExit).toHaveBeenCalledTimes(1)
 
-			testClass.exitProcess(20)
-			await wait(30)
-			expect(mockExit).toHaveBeenCalledTimes(2)
+	// 		testClass.exitProcess(20)
+	// 		await wait(30)
+	// 		expect(mockExit).toHaveBeenCalledTimes(2)
 
-			let mockLog = jest.fn()
-			let orgConsoleLog = console.log
-			console.log = mockLog
+	// 		let mockLog = jest.fn()
+	// 		let orgConsoleLog = console.log
+	// 		console.log = mockLog
 
-			testClass.logSomething('aa', 'bb')
+	// 		testClass.logSomething('aa', 'bb')
 
-			console.log = orgConsoleLog
+	// 		console.log = orgConsoleLog
 
-			expect(mockLog).toHaveBeenCalledTimes(1)
-			expect(mockLog.mock.calls[0]).toEqual(['aa', 'bb'])
+	// 		expect(mockLog).toHaveBeenCalledTimes(1)
+	// 		expect(mockLog.mock.calls[0]).toEqual(['aa', 'bb'])
 
-			expect(await testClass.waitReply(10, 'test11')).toEqual('test11')
-		}
-	})
-	function wait (time: number) {
-		return new Promise((resolve) => {
-			setTimeout(resolve, time)
-		})
-	}
+	// 		expect(await testClass.waitReply(10, 'test11')).toEqual('test11')
+	// 	}
+	// })
+	// function wait (time: number) {
+	// 	return new Promise((resolve) => {
+	// 		setTimeout(resolve, time)
+	// 	})
+	// }
 })

--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -1,5 +1,3 @@
-// import { StringDecoder } from 'string_decoder'
-// import { CasparCG } from 'casparcg-connection'
 import {
 	threadedClass,
 	ThreadedClassManager,
@@ -123,42 +121,6 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		// })
 
-		// test('import library class', async () => {
-
-		// 	let original = new CasparCG({
-		// 		host: '192.168.0.1',
-		// 		autoConnect: false
-		// 	})
-		// 	expect(original.host).toEqual('192.168.0.1')
-
-		// 	let threaded = await threadedClass<CasparCG, typeof CasparCG>('casparcg-connection', 'CasparCG', [{
-		// 		host: '192.168.0.1',
-		// 		autoConnect: false
-		// 	}], { disableMultithreading })
-		// 	expect(await threaded.host).toEqual('192.168.0.1')
-
-		// 	await ThreadedClassManager.destroy(threaded)
-		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		// })
-
-		// test('import native class', async () => {
-
-		// 	let original = new StringDecoder('utf8')
-
-		// 	// €-sign:
-		// 	let euroSign = original.end(Buffer.from([0xE2, 0x82, 0xAC]))
-		// 	expect(euroSign).toEqual('€')
-
-		// 	let threaded = await threadedClass<StringDecoder, typeof StringDecoder>('string_decoder', 'StringDecoder', ['utf8'], { disableMultithreading })
-
-		// 	let euroSign2 = await threaded.end(Buffer.from([0xE2, 0x82, 0xAC]))
-
-		// 	expect(euroSign2).toEqual(euroSign)
-
-		// 	await ThreadedClassManager.destroy(threaded)
-
-		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		// })
 		// if (doPerformanceTests) {
 		// 	test('single-thread', async () => {
 		// 		// let startTime = Date.now()

--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -82,129 +82,129 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(error).toMatch(/Cannot find module/)
 
 		})
-		test('eventEmitter', async () => {
+		// test('eventEmitter', async () => {
 
-			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
+		// 	let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
 
-			let onEvent = jest.fn()
-			await threaded.on('test', onEvent)
+		// 	let onEvent = jest.fn()
+		// 	await threaded.on('test', onEvent)
 
-			await threaded.doEmit('test')
+		// 	await threaded.doEmit('test')
 
-			await new Promise((resolve) => { setTimeout(resolve, 200) })
-			expect(onEvent).toHaveBeenCalledTimes(1)
+		// 	await new Promise((resolve) => { setTimeout(resolve, 200) })
+		// 	expect(onEvent).toHaveBeenCalledTimes(1)
 
-			await ThreadedClassManager.destroy(threaded)
-			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		})
+		// 	await ThreadedClassManager.destroy(threaded)
+		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		// })
 
-		test('method with callback', async () => {
+		// test('method with callback', async () => {
 
-			let original = new House(['north', 'west'], ['south'])
+		// 	let original = new House(['north', 'west'], ['south'])
 
-			let result = await original.callCallback('parent', (str) => {
-				return Promise.resolve(str + ',parent2')
-			})
+		// 	let result = await original.callCallback('parent', (str) => {
+		// 		return Promise.resolve(str + ',parent2')
+		// 	})
 
-			expect(result).toEqual('parent,child,parent2,child2')
+		// 	expect(result).toEqual('parent,child,parent2,child2')
 
-			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
+		// 	let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
 
-			let onEvent = jest.fn()
-			await threaded.on('test', onEvent)
+		// 	let onEvent = jest.fn()
+		// 	await threaded.on('test', onEvent)
 
-			result = await threaded.callCallback('parent', (str: any) => {
-				return str + ',parent2'
-			})
+		// 	result = await threaded.callCallback('parent', (str: any) => {
+		// 		return str + ',parent2'
+		// 	})
 
-			// await new Promise((resolve) => { setTimeout(resolve, 200) })
-			expect(result).toEqual('parent,child,parent2,child2')
+		// 	// await new Promise((resolve) => { setTimeout(resolve, 200) })
+		// 	expect(result).toEqual('parent,child,parent2,child2')
 
-			await ThreadedClassManager.destroy(threaded)
-			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		})
+		// 	await ThreadedClassManager.destroy(threaded)
+		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		// })
 
-		test('import library class', async () => {
+		// test('import library class', async () => {
 
-			let original = new CasparCG({
-				host: '192.168.0.1',
-				autoConnect: false
-			})
-			expect(original.host).toEqual('192.168.0.1')
+		// 	let original = new CasparCG({
+		// 		host: '192.168.0.1',
+		// 		autoConnect: false
+		// 	})
+		// 	expect(original.host).toEqual('192.168.0.1')
 
-			let threaded = await threadedClass<CasparCG, typeof CasparCG>('casparcg-connection', 'CasparCG', [{
-				host: '192.168.0.1',
-				autoConnect: false
-			}], { disableMultithreading })
-			expect(await threaded.host).toEqual('192.168.0.1')
+		// 	let threaded = await threadedClass<CasparCG, typeof CasparCG>('casparcg-connection', 'CasparCG', [{
+		// 		host: '192.168.0.1',
+		// 		autoConnect: false
+		// 	}], { disableMultithreading })
+		// 	expect(await threaded.host).toEqual('192.168.0.1')
 
-			await ThreadedClassManager.destroy(threaded)
-			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		})
+		// 	await ThreadedClassManager.destroy(threaded)
+		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		// })
 
-		test('import native class', async () => {
+		// test('import native class', async () => {
 
-			let original = new StringDecoder('utf8')
+		// 	let original = new StringDecoder('utf8')
 
-			// €-sign:
-			let euroSign = original.end(Buffer.from([0xE2, 0x82, 0xAC]))
-			expect(euroSign).toEqual('€')
+		// 	// €-sign:
+		// 	let euroSign = original.end(Buffer.from([0xE2, 0x82, 0xAC]))
+		// 	expect(euroSign).toEqual('€')
 
-			let threaded = await threadedClass<StringDecoder, typeof StringDecoder>('string_decoder', 'StringDecoder', ['utf8'], { disableMultithreading })
+		// 	let threaded = await threadedClass<StringDecoder, typeof StringDecoder>('string_decoder', 'StringDecoder', ['utf8'], { disableMultithreading })
 
-			let euroSign2 = await threaded.end(Buffer.from([0xE2, 0x82, 0xAC]))
+		// 	let euroSign2 = await threaded.end(Buffer.from([0xE2, 0x82, 0xAC]))
 
-			expect(euroSign2).toEqual(euroSign)
+		// 	expect(euroSign2).toEqual(euroSign)
 
-			await ThreadedClassManager.destroy(threaded)
+		// 	await ThreadedClassManager.destroy(threaded)
 
-			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		})
-		if (doPerformanceTests) {
-			test('single-thread', async () => {
-				// let startTime = Date.now()
-				let results: Array<number> = []
-				for (let i = 0; i < 5; i++) {
+		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		// })
+		// if (doPerformanceTests) {
+		// 	test('single-thread', async () => {
+		// 		// let startTime = Date.now()
+		// 		let results: Array<number> = []
+		// 		for (let i = 0; i < 5; i++) {
 
-					let myHouse = new House(['aa', 'bb'], [])
+		// 			let myHouse = new House(['aa', 'bb'], [])
 
-					results.push(myHouse.slowFib(37))
-				}
-				// let endTime = Date.now()
+		// 			results.push(myHouse.slowFib(37))
+		// 		}
+		// 		// let endTime = Date.now()
 
-				// console.log('Single-thread: ', results.length, endTime - startTime)
-				expect(results).toHaveLength(5)
-			})
-			test('multi-thread', async () => {
-				// let startTime = Date.now()
-				let threads: ThreadedClass<House>[] = []
-				let results: Array<number> = []
+		// 		// console.log('Single-thread: ', results.length, endTime - startTime)
+		// 		expect(results).toHaveLength(5)
+		// 	})
+		// 	test('multi-thread', async () => {
+		// 		// let startTime = Date.now()
+		// 		let threads: ThreadedClass<House>[] = []
+		// 		let results: Array<number> = []
 
-				let ps: any = []
+		// 		let ps: any = []
 
-				for (let i = 0; i < 5; i++) {
-					ps.push(
-						threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['aa', 'bb'], []], { disableMultithreading })
-						.then((myHouse) => {
-							threads.push(myHouse)
-							return myHouse.slowFib(37)
-						})
-						.then((result) => {
-							results.push(result)
-						})
-					)
-				}
-				await Promise.all(ps)
-				// let endTime = Date.now()
-				await Promise.all(threads.map((thread) => {
-					return ThreadedClassManager.destroy(thread)
-				}))
+		// 		for (let i = 0; i < 5; i++) {
+		// 			ps.push(
+		// 				threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['aa', 'bb'], []], { disableMultithreading })
+		// 				.then((myHouse) => {
+		// 					threads.push(myHouse)
+		// 					return myHouse.slowFib(37)
+		// 				})
+		// 				.then((result) => {
+		// 					results.push(result)
+		// 				})
+		// 			)
+		// 		}
+		// 		await Promise.all(ps)
+		// 		// let endTime = Date.now()
+		// 		await Promise.all(threads.map((thread) => {
+		// 			return ThreadedClassManager.destroy(thread)
+		// 		}))
 
-				// console.log('Multi-thread: ', results.length, endTime - startTime)
-				expect(results).toHaveLength(5)
-				expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-			})
-		}
+		// 		// console.log('Multi-thread: ', results.length, endTime - startTime)
+		// 		expect(results).toHaveLength(5)
+		// 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		// 	})
+		// }
 		test('properties', async () => {
 			let original = new House([], ['south'])
 			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [[], ['south']], { disableMultithreading })
@@ -486,15 +486,15 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	await ThreadedClassManager.destroy(threaded)
 		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		// })
-		test('execute callback loaded via function', async () => {
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
+		// test('execute callback loaded via function', async () => {
+		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
-			await threaded.setParam1((num0: number, num1: number): number => num0 + num1 + 1)
-			expect(await threaded.callParam1(40, 1)).toEqual(42)
+		// 	await threaded.setParam1((num0: number, num1: number): number => num0 + num1 + 1)
+		// 	expect(await threaded.callParam1(40, 1)).toEqual(42)
 
-			await ThreadedClassManager.destroy(threaded)
-			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		})
+		// 	await ThreadedClassManager.destroy(threaded)
+		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		// })
 		// test('execute wrapped callback loaded via setter', async () => {
 		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
@@ -504,136 +504,136 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	await ThreadedClassManager.destroy(threaded)
 		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		// })
-		test('execute callback loaded via setter', async () => {
-			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
+		// test('execute callback loaded via setter', async () => {
+		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
-			threaded.Param1 = (num0: number, num1: number): Promise<number> => Promise.resolve(num0 + num1 + 1)
-			expect(await threaded.callParam1(40, 1)).toEqual(42)
+		// 	threaded.Param1 = (num0: number, num1: number): Promise<number> => Promise.resolve(num0 + num1 + 1)
+		// 	expect(await threaded.callParam1(40, 1)).toEqual(42)
 
-			await ThreadedClassManager.destroy(threaded)
-			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		})
-		test('functions as arguments', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
+		// 	await ThreadedClassManager.destroy(threaded)
+		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		// })
+		// test('functions as arguments', async () => {
+		// 	let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
-			let i = 0
-			const calledSecond = jest.fn((a,b) => {
-				expect(a).toEqual(3)
-				expect(b).toEqual(4)
+		// 	let i = 0
+		// 	const calledSecond = jest.fn((a,b) => {
+		// 		expect(a).toEqual(3)
+		// 		expect(b).toEqual(4)
 
-				expect(i++).toEqual(3)
+		// 		expect(i++).toEqual(3)
 
-				return 42
-			})
-			const calledFirst = jest.fn(async (a,b,c) => {
-				expect(a).toEqual(1)
-				expect(b).toEqual(2)
-				expect(c).toEqual(3)
-				expect(i++).toEqual(1)
+		// 		return 42
+		// 	})
+		// 	const calledFirst = jest.fn(async (a,b,c) => {
+		// 		expect(a).toEqual(1)
+		// 		expect(b).toEqual(2)
+		// 		expect(c).toEqual(3)
+		// 		expect(i++).toEqual(1)
 
-				// return calledSecond
-				return threaded.callFunction((a: number, b: number) => {
-					expect(a).toEqual(6)
-					expect(b).toEqual(7)
-					expect(i++).toEqual(2)
+		// 		// return calledSecond
+		// 		return threaded.callFunction((a: number, b: number) => {
+		// 			expect(a).toEqual(6)
+		// 			expect(b).toEqual(7)
+		// 			expect(i++).toEqual(2)
 
-					return calledSecond
-				}, 6,7)
-			})
+		// 			return calledSecond
+		// 		}, 6,7)
+		// 	})
 
-			expect(i++).toEqual(0)
-			const f0: any = await threaded.callFunction(calledFirst, 1, 2, 3)
-			expect(calledFirst).toHaveBeenCalledTimes(1)
+		// 	expect(i++).toEqual(0)
+		// 	const f0: any = await threaded.callFunction(calledFirst, 1, 2, 3)
+		// 	expect(calledFirst).toHaveBeenCalledTimes(1)
 
-			expect(
-				await f0(3,4) // will cause calledSecond to be called
-			).toEqual(42)
+		// 	expect(
+		// 		await f0(3,4) // will cause calledSecond to be called
+		// 	).toEqual(42)
 
-			expect(calledSecond).toHaveBeenCalledTimes(1)
+		// 	expect(calledSecond).toHaveBeenCalledTimes(1)
 
-			/*
-				What happened in detail:
-				* threaded.callFunction was executed on parent
-					* TestFunction.callFunction was executed on worker
-						* calledFirst was executed on parent
-							* TestFunction.callFunction was executed on worker
-								* unnamed arrow function was executed on parent
-									-> returns a reference to calledSecond
-				v ------------------
-				-> returns the reference to calledSecond
+		// 	/*
+		// 		What happened in detail:
+		// 		* threaded.callFunction was executed on parent
+		// 			* TestFunction.callFunction was executed on worker
+		// 				* calledFirst was executed on parent
+		// 					* TestFunction.callFunction was executed on worker
+		// 						* unnamed arrow function was executed on parent
+		// 							-> returns a reference to calledSecond
+		// 		v ------------------
+		// 		-> returns the reference to calledSecond
 
-				* f0 was executed
-			*/
-		})
+		// 		* f0 was executed
+		// 	*/
+		// })
 
-		test('error handling', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
+		// test('error handling', async () => {
+		// 	let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
-			let error: any = null
+		// 	let error: any = null
 
-			try {
-				await threaded.throwError()
-			} catch (e) {
-				error = e
-			}
-			expect(error.toString()).toMatch(/Error thrown/)
-			error = null
-			try {
-				await threaded.throwErrorString()
-			} catch (e) {
-				error = e
-			}
-			expect(error.toString()).toMatch(/Error string thrown/)
+		// 	try {
+		// 		await threaded.throwError()
+		// 	} catch (e) {
+		// 		error = e
+		// 	}
+		// 	expect(error.toString()).toMatch(/Error thrown/)
+		// 	error = null
+		// 	try {
+		// 		await threaded.throwErrorString()
+		// 	} catch (e) {
+		// 		error = e
+		// 	}
+		// 	expect(error.toString()).toMatch(/Error string thrown/)
 
-			error = null
-			try {
-				await threaded.callFunction(() => {
-					throw new Error('Error thrown in callback')
-				})
-			} catch (e) {
-				error = e
-			}
-			expect(error.toString()).toMatch(/Error thrown in callback/)
+		// 	error = null
+		// 	try {
+		// 		await threaded.callFunction(() => {
+		// 			throw new Error('Error thrown in callback')
+		// 		})
+		// 	} catch (e) {
+		// 		error = e
+		// 	}
+		// 	expect(error.toString()).toMatch(/Error thrown in callback/)
 
-			error = null
-			try {
-				await threaded.callFunction(() => {
-					return Promise.reject('Reject in callback')
-				})
-			} catch (e) {
-				error = e
-			}
-			expect(error.toString()).toMatch(/Reject in callback/)
+		// 	error = null
+		// 	try {
+		// 		await threaded.callFunction(() => {
+		// 			return Promise.reject('Reject in callback')
+		// 		})
+		// 	} catch (e) {
+		// 		error = e
+		// 	}
+		// 	expect(error.toString()).toMatch(/Reject in callback/)
 
-			error = null
-			const secondaryFunction = () => {
-				throw new Error('Error thrown in secondary')
-			}
-			try {
-				let second: any = await threaded.callFunction(() => {
-					return secondaryFunction
-				})
-				await second('second')
-			} catch (e) {
-				error = e
-			}
-			expect(error && error.toString()).toMatch(/Error thrown in secondary/)
+		// 	error = null
+		// 	const secondaryFunction = () => {
+		// 		throw new Error('Error thrown in secondary')
+		// 	}
+		// 	try {
+		// 		let second: any = await threaded.callFunction(() => {
+		// 			return secondaryFunction
+		// 		})
+		// 		await second('second')
+		// 	} catch (e) {
+		// 		error = e
+		// 	}
+		// 	expect(error && error.toString()).toMatch(/Error thrown in secondary/)
 
-			error = null
-			const secondaryFunctionReject = () => {
-				return Promise.reject('Reject in secondary')
-			}
-			try {
-				let second: any = await threaded.callFunction(() => {
-					return secondaryFunctionReject
-				})
-				await second('second')
-			} catch (e) {
-				error = e
-			}
-			expect(error && error.toString()).toMatch(/Reject in secondary/)
+		// 	error = null
+		// 	const secondaryFunctionReject = () => {
+		// 		return Promise.reject('Reject in secondary')
+		// 	}
+		// 	try {
+		// 		let second: any = await threaded.callFunction(() => {
+		// 			return secondaryFunctionReject
+		// 		})
+		// 		await second('second')
+		// 	} catch (e) {
+		// 		error = e
+		// 	}
+		// 	expect(error && error.toString()).toMatch(/Reject in secondary/)
 
-		})
+		// })
 		test('logging', async () => {
 			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
@@ -652,27 +652,27 @@ const getTests = (disableMultithreading: boolean) => {
 				expect(mockLog.mock.calls[0]).toEqual(['', 'aa', 'bb'])
 			}
 		})
-		test('EventEmitter', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
+		// test('EventEmitter', async () => {
+		// 	let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
-			const eventListener0 = jest.fn()
-			const eventListener1 = jest.fn()
-			await threaded.on('event0', eventListener0)
-			await threaded.on('event1', eventListener1)
+		// 	const eventListener0 = jest.fn()
+		// 	const eventListener1 = jest.fn()
+		// 	await threaded.on('event0', eventListener0)
+		// 	await threaded.on('event1', eventListener1)
 
-			await threaded.emitMessage('event0', 'a')
-			await threaded.emitMessage('event1', 'b')
+		// 	await threaded.emitMessage('event0', 'a')
+		// 	await threaded.emitMessage('event1', 'b')
 
-			expect(eventListener0).toHaveBeenCalledTimes(1)
-			expect(eventListener0).toHaveBeenCalledWith('a')
-			expect(eventListener1).toHaveBeenCalledTimes(1)
-			expect(eventListener1).toHaveBeenCalledWith('b')
+		// 	expect(eventListener0).toHaveBeenCalledTimes(1)
+		// 	expect(eventListener0).toHaveBeenCalledWith('a')
+		// 	expect(eventListener1).toHaveBeenCalledTimes(1)
+		// 	expect(eventListener1).toHaveBeenCalledWith('b')
 
-			let self = await threaded.getSelf()
+		// 	let self = await threaded.getSelf()
 
-			expect(self).toEqual(threaded)
+		// 	expect(self).toEqual(threaded)
 
-		})
+		// })
 		test('import typescript', async () => {
 			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH_UNSYNCED, 'TestClass', [], { disableMultithreading })
 
@@ -739,47 +739,47 @@ describe('threadedclass', getTests(false))
 // describe('threadedclass single thread', getTests(true))
 
 // Test on behaviour that differ bewteen Multi-threading vs none
-describe('single-thread tests', () => {
-	const disableMultithreading = true
-	test('Buffer', async () => {
-		let original = new TestClass()
+// describe('single-thread tests', () => {
+// 	const disableMultithreading = true
+// 	test('Buffer', async () => {
+// 		let original = new TestClass()
 
-		let bugString = '123456789abcfdef'
+// 		let bugString = '123456789abcfdef'
 
-		let buf = Buffer.from(bugString)
-		let buf2 = buf
-		let buf3 = Buffer.from(bugString)
+// 		let buf = Buffer.from(bugString)
+// 		let buf2 = buf
+// 		let buf3 = Buffer.from(bugString)
 
-		expect(buf === buf2).toEqual(true)
-		expect(buf === buf3).toEqual(false)
+// 		expect(buf === buf2).toEqual(true)
+// 		expect(buf === buf3).toEqual(false)
 
-		expect((original.returnValue(buf)) === buf2).toEqual(true)
-		expect((original.returnValue(buf)) === buf3).toEqual(false)
+// 		expect((original.returnValue(buf)) === buf2).toEqual(true)
+// 		expect((original.returnValue(buf)) === buf3).toEqual(false)
 
-		let singleThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
-		let onClosed = jest.fn()
-		ThreadedClassManager.onEvent(singleThreaded, 'thread_closed', onClosed)
+// 		let singleThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
+// 		let onClosed = jest.fn()
+// 		ThreadedClassManager.onEvent(singleThreaded, 'thread_closed', onClosed)
 
-		let multiThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], {})
-		let onClosed2 = jest.fn()
-		ThreadedClassManager.onEvent(multiThreaded, 'thread_closed', onClosed2)
+// 		let multiThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], {})
+// 		let onClosed2 = jest.fn()
+// 		ThreadedClassManager.onEvent(multiThreaded, 'thread_closed', onClosed2)
 
-		// Handle buffers correctly in single threaded mode
-		expect((await singleThreaded.returnValue(buf)) === buf2).toEqual(true)
-		expect((await singleThreaded.returnValue(buf)) === buf3).toEqual(false)
+// 		// Handle buffers correctly in single threaded mode
+// 		expect((await singleThreaded.returnValue(buf)) === buf2).toEqual(true)
+// 		expect((await singleThreaded.returnValue(buf)) === buf3).toEqual(false)
 
-		// Not possible to handle buffers correctly in threaded mode
-		expect((await multiThreaded.returnValue(buf)) === buf2).toEqual(false)
-		expect((await multiThreaded.returnValue(buf)) === buf3).toEqual(false)
-		// However the values of the buffers should be correct:
-		expect((await multiThreaded.returnValue(buf) as any).toString() === buf2.toString()).toEqual(true)
-		expect((await multiThreaded.returnValue(buf) as any).toString() === buf3.toString()).toEqual(true)
+// 		// Not possible to handle buffers correctly in threaded mode
+// 		expect((await multiThreaded.returnValue(buf)) === buf2).toEqual(false)
+// 		expect((await multiThreaded.returnValue(buf)) === buf3).toEqual(false)
+// 		// However the values of the buffers should be correct:
+// 		expect((await multiThreaded.returnValue(buf) as any).toString() === buf2.toString()).toEqual(true)
+// 		expect((await multiThreaded.returnValue(buf) as any).toString() === buf3.toString()).toEqual(true)
 
-		await ThreadedClassManager.destroy(singleThreaded)
-		await ThreadedClassManager.destroy(multiThreaded)
-		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+// 		await ThreadedClassManager.destroy(singleThreaded)
+// 		await ThreadedClassManager.destroy(multiThreaded)
+// 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
-		expect(onClosed).toHaveBeenCalledTimes(1)
-		expect(onClosed2).toHaveBeenCalledTimes(1)
-	})
-})
+// 		expect(onClosed).toHaveBeenCalledTimes(1)
+// 		expect(onClosed2).toHaveBeenCalledTimes(1)
+// 	})
+// })

--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -1,9 +1,9 @@
-import { StringDecoder } from 'string_decoder'
-import { CasparCG } from 'casparcg-connection'
+// import { StringDecoder } from 'string_decoder'
+// import { CasparCG } from 'casparcg-connection'
 import {
 	threadedClass,
 	ThreadedClassManager,
-	ThreadedClass
+	// ThreadedClass
 } from '../index'
 import { House } from '../../test-lib/house'
 import { TestClass } from '../../test-lib/testClass'
@@ -13,7 +13,7 @@ import { ThreadMode } from '../manager'
 const HOUSE_PATH = '../../test-lib/house.js'
 const RENAME_PATH = '../../test-lib/rename.js'
 const TESTCLASS_PATH = '../../test-lib/testClass.js'
-const TESTCLASS_PATH_UNSYNCED = '../../test-lib/testClass-unsynced.js'
+// const TESTCLASS_PATH_UNSYNCED = '../../test-lib/testClass-unsynced.js'
 
 // function wait (time: number) {
 // 	return new Promise((resolve) => {
@@ -21,7 +21,7 @@ const TESTCLASS_PATH_UNSYNCED = '../../test-lib/testClass-unsynced.js'
 // 	})
 // }
 
-const doPerformanceTests = false
+// const doPerformanceTests = false
 
 const getTests = (disableMultithreading: boolean) => {
 	return () => {
@@ -38,8 +38,8 @@ const getTests = (disableMultithreading: boolean) => {
 
 			let original = new House(['north', 'west'], ['south'])
 
-			expect(original.getWindows('')).toHaveLength(2)
-			expect(original.getRooms()).toHaveLength(1)
+			expect(await original.getWindows('')).toHaveLength(2)
+			expect(await original.getRooms()).toHaveLength(1)
 
 			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
 			let onClosed = jest.fn()
@@ -58,7 +58,7 @@ const getTests = (disableMultithreading: boolean) => {
 		test('import own basic class', async () => {
 			let original = new TestClass()
 
-			expect(original.returnValue('asdf')).toEqual('asdf')
+			expect(await original.returnValue('asdf')).toEqual('asdf')
 
 			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 			let onClosed = jest.fn()
@@ -70,7 +70,6 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
 			expect(onClosed).toHaveBeenCalledTimes(1)
-
 		})
 		test('import wrong path', async () => {
 			let error: any = null
@@ -210,56 +209,56 @@ const getTests = (disableMultithreading: boolean) => {
 			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [[], ['south']], { disableMultithreading })
 
 			// Method with parameter and return value:
-			expect(original.returnValue('myValue')).toEqual('myValue')
+			expect(await original.returnValue('myValue')).toEqual('myValue')
 			//
 			expect(await threaded.returnValue('myValue')).toEqual('myValue')
 
 			// Method to set and get value:
-			original.setWindows(['west', 'south'])
-			expect(original.getWindows('')).toHaveLength(2)
+			await original.setWindows(['west', 'south'])
+			expect(await original.getWindows('')).toHaveLength(2)
 			//
 			await threaded.setWindows(['west', 'south'])
 			expect(await threaded.getWindows('')).toHaveLength(2)
 
-			// Public property:
-			original.windows = ['a','b','c','d']
-			expect(original.windows).toEqual(['a','b','c','d'])
-			//
-			// @ts-ignore this technically works, though the typings do not:
-			threaded.windows = ['a','b','c','d']
-			expect(await threaded.windows).toEqual(['a','b','c','d'])
+		// 	// Public property:
+		// 	original.windows = ['a','b','c','d']
+		// 	expect(original.windows).toEqual(['a','b','c','d'])
+		// 	//
+		// 	// @ts-ignore this technically works, though the typings do not:
+		// 	threaded.windows = ['a','b','c','d']
+		// 	expect(await threaded.windows).toEqual(['a','b','c','d'])
 
 			// Method to get private property:
-			expect(original.getRooms()).toHaveLength(1)
+			expect(await original.getRooms()).toHaveLength(1)
 			//
 			expect(await threaded.getRooms()).toHaveLength(1)
 
-			// Getter to get private property:
-			expect(original.getterRooms).toHaveLength(1)
-			//
-			expect(await threaded.getterRooms).toHaveLength(1)
+		// 	// Getter to get private property:
+		// 	expect(original.getterRooms).toHaveLength(1)
+		// 	//
+		// 	expect(await threaded.getterRooms).toHaveLength(1)
 
-			// Private property that has both a getter and a setter:
-			original.lamps = 91
-			expect(original.lamps).toEqual(91)
-			//
-			// @ts-ignore this technically works, though the typings do not:
-			threaded.lamps = 91
-			expect(await threaded.lamps).toEqual(91)
+		// 	// Private property that has both a getter and a setter:
+		// 	original.lamps = 91
+		// 	expect(original.lamps).toEqual(91)
+		// 	//
+		// 	// @ts-ignore this technically works, though the typings do not:
+		// 	threaded.lamps = 91
+		// 	expect(await threaded.lamps).toEqual(91)
 
-			// Private property that only has getter:
-			expect(original.readonly).toEqual(42)
-			// original.readonly = 3 // not allowed according to types (which is correct)
-			//
-			expect(await threaded.readonly).toEqual(42)
+		// 	// Private property that only has getter:
+		// 	expect(original.readonly).toEqual(42)
+		// 	// original.readonly = 3 // not allowed according to types (which is correct)
+		// 	//
+		// 	expect(await threaded.readonly).toEqual(42)
 
-			// Private property that only has setter:
-			original.writeonly = 13
-			expect(original.writeonly).toEqual(undefined)
-			//
-			// @ts-ignore this technically works, though the typings do not:
-			threaded.writeonly = 13
-			expect(await threaded.writeonly).toEqual(undefined)
+		// 	// Private property that only has setter:
+		// 	original.writeonly = 13
+		// 	expect(original.writeonly).toEqual(undefined)
+		// 	//
+		// 	// @ts-ignore this technically works, though the typings do not:
+		// 	threaded.writeonly = 13
+		// 	expect(await threaded.writeonly).toEqual(undefined)
 
 			await ThreadedClassManager.destroy(threaded)
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
@@ -455,7 +454,6 @@ const getTests = (disableMultithreading: boolean) => {
 
 			// await ThreadedClassManager.destroy(threaded)
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-
 		})
 		// test('execute wrapped callback loaded via constructor', async () => {
 		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [
@@ -632,7 +630,6 @@ const getTests = (disableMultithreading: boolean) => {
 		// 		error = e
 		// 	}
 		// 	expect(error && error.toString()).toMatch(/Reject in secondary/)
-
 		// })
 		test('logging', async () => {
 			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
@@ -673,20 +670,20 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	expect(self).toEqual(threaded)
 
 		// })
-		test('import typescript', async () => {
-			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH_UNSYNCED, 'TestClass', [], { disableMultithreading })
+		// test('import typescript', async () => {
+		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH_UNSYNCED, 'TestClass', [], { disableMultithreading })
 
-			let id = await threaded.getId()
+		// 	let id = await threaded.getId()
 
-			if (disableMultithreading) {
-				// expect the ts file to have been loaded:
-				expect(id).toEqual('abc')
-			} else {
-				// expect the js file to have been loaded:
-				expect(id).toEqual('unsynced')
-			}
+		// 	if (disableMultithreading) {
+		// 		// expect the ts file to have been loaded:
+		// 		expect(id).toEqual('abc')
+		// 	} else {
+		// 		// expect the js file to have been loaded:
+		// 		expect(id).toEqual('unsynced')
+		// 	}
 
-		})
+		// })
 		test('export name mismatch', async () => {
 			let threaded = await threadedClass<AlmostTestClass, typeof AlmostTestClass>(RENAME_PATH, 'AlmostTestClass', [], { disableMultithreading })
 
@@ -697,7 +694,7 @@ const getTests = (disableMultithreading: boolean) => {
 		test('circular object', async () => {
 			let original = new TestClass()
 
-			expect(original.returnValue('asdf')).toEqual('asdf')
+			expect(await original.returnValue('asdf')).toEqual('asdf')
 
 			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading, instanceName: 'myInstance' })
 			let onClosed = jest.fn()
@@ -736,50 +733,50 @@ const getTests = (disableMultithreading: boolean) => {
 }
 
 describe('threadedclass', getTests(false))
-// describe('threadedclass single thread', getTests(true))
+describe('threadedclass single thread', getTests(true))
 
 // Test on behaviour that differ bewteen Multi-threading vs none
-// describe('single-thread tests', () => {
-// 	const disableMultithreading = true
-// 	test('Buffer', async () => {
-// 		let original = new TestClass()
+describe('single-thread tests', () => {
+	const disableMultithreading = true
+	test('Buffer', async () => {
+		let original = new TestClass()
 
-// 		let bugString = '123456789abcfdef'
+		let bugString = '123456789abcfdef'
 
-// 		let buf = Buffer.from(bugString)
-// 		let buf2 = buf
-// 		let buf3 = Buffer.from(bugString)
+		let buf = Buffer.from(bugString)
+		let buf2 = buf
+		let buf3 = Buffer.from(bugString)
 
-// 		expect(buf === buf2).toEqual(true)
-// 		expect(buf === buf3).toEqual(false)
+		expect(buf === buf2).toEqual(true)
+		expect(buf === buf3).toEqual(false)
 
-// 		expect((original.returnValue(buf)) === buf2).toEqual(true)
-// 		expect((original.returnValue(buf)) === buf3).toEqual(false)
+		expect((await original.returnValue(buf)) === buf2).toEqual(true)
+		expect((await original.returnValue(buf)) === buf3).toEqual(false)
 
-// 		let singleThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
-// 		let onClosed = jest.fn()
-// 		ThreadedClassManager.onEvent(singleThreaded, 'thread_closed', onClosed)
+		let singleThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
+		let onClosed = jest.fn()
+		ThreadedClassManager.onEvent(singleThreaded, 'thread_closed', onClosed)
 
-// 		let multiThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], {})
-// 		let onClosed2 = jest.fn()
-// 		ThreadedClassManager.onEvent(multiThreaded, 'thread_closed', onClosed2)
+		let multiThreaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], {})
+		let onClosed2 = jest.fn()
+		ThreadedClassManager.onEvent(multiThreaded, 'thread_closed', onClosed2)
 
-// 		// Handle buffers correctly in single threaded mode
-// 		expect((await singleThreaded.returnValue(buf)) === buf2).toEqual(true)
-// 		expect((await singleThreaded.returnValue(buf)) === buf3).toEqual(false)
+		// Handle buffers correctly in single threaded mode
+		expect((await singleThreaded.returnValue(buf)) === buf2).toEqual(true)
+		expect((await singleThreaded.returnValue(buf)) === buf3).toEqual(false)
 
-// 		// Not possible to handle buffers correctly in threaded mode
-// 		expect((await multiThreaded.returnValue(buf)) === buf2).toEqual(false)
-// 		expect((await multiThreaded.returnValue(buf)) === buf3).toEqual(false)
-// 		// However the values of the buffers should be correct:
-// 		expect((await multiThreaded.returnValue(buf) as any).toString() === buf2.toString()).toEqual(true)
-// 		expect((await multiThreaded.returnValue(buf) as any).toString() === buf3.toString()).toEqual(true)
+		// Not possible to handle buffers correctly in threaded mode
+		expect((await multiThreaded.returnValue(buf)) === buf2).toEqual(false)
+		expect((await multiThreaded.returnValue(buf)) === buf3).toEqual(false)
+		// However the values of the buffers should be correct:
+		expect((await multiThreaded.returnValue(buf) as any).toString() === buf2.toString()).toEqual(true)
+		expect((await multiThreaded.returnValue(buf) as any).toString() === buf3.toString()).toEqual(true)
 
-// 		await ThreadedClassManager.destroy(singleThreaded)
-// 		await ThreadedClassManager.destroy(multiThreaded)
-// 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		await ThreadedClassManager.destroy(singleThreaded)
+		await ThreadedClassManager.destroy(multiThreaded)
+		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 
-// 		expect(onClosed).toHaveBeenCalledTimes(1)
-// 		expect(onClosed2).toHaveBeenCalledTimes(1)
-// 	})
-// })
+		expect(onClosed).toHaveBeenCalledTimes(1)
+		expect(onClosed2).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -1,7 +1,7 @@
 import {
 	threadedClass,
 	ThreadedClassManager,
-	// ThreadedClass
+	ThreadedClass
 } from '../index'
 import { House } from '../../test-lib/house'
 import { TestClass } from '../../test-lib/testClass'
@@ -19,7 +19,7 @@ const TESTCLASS_PATH = '../../test-lib/testClass.js'
 // 	})
 // }
 
-// const doPerformanceTests = false
+const doPerformanceTests = false
 
 const getTests = (disableMultithreading: boolean) => {
 	return () => {
@@ -79,93 +79,93 @@ const getTests = (disableMultithreading: boolean) => {
 			expect(error).toMatch(/Cannot find module/)
 
 		})
-		// test('eventEmitter', async () => {
+		test('eventEmitter', async () => {
 
-		// 	let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
+			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
 
-		// 	let onEvent = jest.fn()
-		// 	await threaded.on('test', onEvent)
+			let onEvent = jest.fn()
+			await threaded.on('test', onEvent)
 
-		// 	await threaded.doEmit('test')
+			await threaded.doEmit('test')
 
-		// 	await new Promise((resolve) => { setTimeout(resolve, 200) })
-		// 	expect(onEvent).toHaveBeenCalledTimes(1)
+			await new Promise((resolve) => { setTimeout(resolve, 200) })
+			expect(onEvent).toHaveBeenCalledTimes(1)
 
-		// 	await ThreadedClassManager.destroy(threaded)
-		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		// })
+			await ThreadedClassManager.destroy(threaded)
+			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		})
 
-		// test('method with callback', async () => {
+		test('method with callback', async () => {
 
-		// 	let original = new House(['north', 'west'], ['south'])
+			let original = new House(['north', 'west'], ['south'])
 
-		// 	let result = await original.callCallback('parent', (str) => {
-		// 		return Promise.resolve(str + ',parent2')
-		// 	})
+			let result = await original.callCallback('parent', (str) => {
+				return Promise.resolve(str + ',parent2')
+			})
 
-		// 	expect(result).toEqual('parent,child,parent2,child2')
+			expect(result).toEqual('parent,child,parent2,child2')
 
-		// 	let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
+			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['north', 'west'], ['south']], { disableMultithreading })
 
-		// 	let onEvent = jest.fn()
-		// 	await threaded.on('test', onEvent)
+			let onEvent = jest.fn()
+			await threaded.on('test', onEvent)
 
-		// 	result = await threaded.callCallback('parent', (str: any) => {
-		// 		return str + ',parent2'
-		// 	})
+			result = await threaded.callCallback('parent', async (str: any) => {
+				return str + ',parent2'
+			})
 
-		// 	// await new Promise((resolve) => { setTimeout(resolve, 200) })
-		// 	expect(result).toEqual('parent,child,parent2,child2')
+			// await new Promise((resolve) => { setTimeout(resolve, 200) })
+			expect(result).toEqual('parent,child,parent2,child2')
 
-		// 	await ThreadedClassManager.destroy(threaded)
-		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		// })
+			await ThreadedClassManager.destroy(threaded)
+			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		})
 
-		// if (doPerformanceTests) {
-		// 	test('single-thread', async () => {
-		// 		// let startTime = Date.now()
-		// 		let results: Array<number> = []
-		// 		for (let i = 0; i < 5; i++) {
+		if (doPerformanceTests) {
+			test('single-thread', async () => {
+				// let startTime = Date.now()
+				let results: Array<number> = []
+				for (let i = 0; i < 5; i++) {
 
-		// 			let myHouse = new House(['aa', 'bb'], [])
+					let myHouse = new House(['aa', 'bb'], [])
 
-		// 			results.push(myHouse.slowFib(37))
-		// 		}
-		// 		// let endTime = Date.now()
+					results.push(await myHouse.slowFib(37))
+				}
+				// let endTime = Date.now()
 
-		// 		// console.log('Single-thread: ', results.length, endTime - startTime)
-		// 		expect(results).toHaveLength(5)
-		// 	})
-		// 	test('multi-thread', async () => {
-		// 		// let startTime = Date.now()
-		// 		let threads: ThreadedClass<House>[] = []
-		// 		let results: Array<number> = []
+				// console.log('Single-thread: ', results.length, endTime - startTime)
+				expect(results).toHaveLength(5)
+			})
+			test('multi-thread', async () => {
+				// let startTime = Date.now()
+				let threads: ThreadedClass<House>[] = []
+				let results: Array<number> = []
 
-		// 		let ps: any = []
+				let ps: any = []
 
-		// 		for (let i = 0; i < 5; i++) {
-		// 			ps.push(
-		// 				threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['aa', 'bb'], []], { disableMultithreading })
-		// 				.then((myHouse) => {
-		// 					threads.push(myHouse)
-		// 					return myHouse.slowFib(37)
-		// 				})
-		// 				.then((result) => {
-		// 					results.push(result)
-		// 				})
-		// 			)
-		// 		}
-		// 		await Promise.all(ps)
-		// 		// let endTime = Date.now()
-		// 		await Promise.all(threads.map((thread) => {
-		// 			return ThreadedClassManager.destroy(thread)
-		// 		}))
+				for (let i = 0; i < 5; i++) {
+					ps.push(
+						threadedClass<House, typeof House>(HOUSE_PATH, 'House', [['aa', 'bb'], []], { disableMultithreading })
+						.then((myHouse) => {
+							threads.push(myHouse)
+							return myHouse.slowFib(37)
+						})
+						.then((result) => {
+							results.push(result)
+						})
+					)
+				}
+				await Promise.all(ps)
+				// let endTime = Date.now()
+				await Promise.all(threads.map((thread) => {
+					return ThreadedClassManager.destroy(thread)
+				}))
 
-		// 		// console.log('Multi-thread: ', results.length, endTime - startTime)
-		// 		expect(results).toHaveLength(5)
-		// 		expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		// 	})
-		// }
+				// console.log('Multi-thread: ', results.length, endTime - startTime)
+				expect(results).toHaveLength(5)
+				expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+			})
+		}
 		test('properties', async () => {
 			let original = new House([], ['south'])
 			let threaded = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [[], ['south']], { disableMultithreading })
@@ -446,15 +446,15 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	await ThreadedClassManager.destroy(threaded)
 		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		// })
-		// test('execute callback loaded via function', async () => {
-		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
+		test('execute callback loaded via function', async () => {
+			let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
-		// 	await threaded.setParam1((num0: number, num1: number): number => num0 + num1 + 1)
-		// 	expect(await threaded.callParam1(40, 1)).toEqual(42)
+			await threaded.setParam1((num0: number, num1: number): number => num0 + num1 + 1)
+			expect(await threaded.callParam1(40, 1)).toEqual(42)
 
-		// 	await ThreadedClassManager.destroy(threaded)
-		// 	expect(ThreadedClassManager.getThreadCount()).toEqual(0)
-		// })
+			await ThreadedClassManager.destroy(threaded)
+			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
+		})
 		// test('execute wrapped callback loaded via setter', async () => {
 		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
@@ -526,73 +526,73 @@ const getTests = (disableMultithreading: boolean) => {
 		// 	*/
 		// })
 
-		// test('error handling', async () => {
-		// 	let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
+		test('error handling', async () => {
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
-		// 	let error: any = null
+			let error: any = null
 
-		// 	try {
-		// 		await threaded.throwError()
-		// 	} catch (e) {
-		// 		error = e
-		// 	}
-		// 	expect(error.toString()).toMatch(/Error thrown/)
-		// 	error = null
-		// 	try {
-		// 		await threaded.throwErrorString()
-		// 	} catch (e) {
-		// 		error = e
-		// 	}
-		// 	expect(error.toString()).toMatch(/Error string thrown/)
+			try {
+				await threaded.throwError()
+			} catch (e) {
+				error = e
+			}
+			expect(error.toString()).toMatch(/Error thrown/)
+			error = null
+			try {
+				await threaded.throwErrorString()
+			} catch (e) {
+				error = e
+			}
+			expect(error.toString()).toMatch(/Error string thrown/)
 
-		// 	error = null
-		// 	try {
-		// 		await threaded.callFunction(() => {
-		// 			throw new Error('Error thrown in callback')
-		// 		})
-		// 	} catch (e) {
-		// 		error = e
-		// 	}
-		// 	expect(error.toString()).toMatch(/Error thrown in callback/)
+			error = null
+			try {
+				await threaded.callFunction(async () => {
+					throw new Error('Error thrown in callback')
+				})
+			} catch (e) {
+				error = e
+			}
+			expect(error.toString()).toMatch(/Error thrown in callback/)
 
-		// 	error = null
-		// 	try {
-		// 		await threaded.callFunction(() => {
-		// 			return Promise.reject('Reject in callback')
-		// 		})
-		// 	} catch (e) {
-		// 		error = e
-		// 	}
-		// 	expect(error.toString()).toMatch(/Reject in callback/)
+			error = null
+			try {
+				await threaded.callFunction(async () => {
+					return Promise.reject('Reject in callback')
+				})
+			} catch (e) {
+				error = e
+			}
+			expect(error.toString()).toMatch(/Reject in callback/)
 
-		// 	error = null
-		// 	const secondaryFunction = () => {
-		// 		throw new Error('Error thrown in secondary')
-		// 	}
-		// 	try {
-		// 		let second: any = await threaded.callFunction(() => {
-		// 			return secondaryFunction
-		// 		})
-		// 		await second('second')
-		// 	} catch (e) {
-		// 		error = e
-		// 	}
-		// 	expect(error && error.toString()).toMatch(/Error thrown in secondary/)
+			// error = null
+			// const secondaryFunction = () => {
+			// 	throw new Error('Error thrown in secondary')
+			// }
+			// try {
+			// 	let second: any = await threaded.callFunction(() => {
+			// 		return secondaryFunction
+			// 	})
+			// 	await second('second')
+			// } catch (e) {
+			// 	error = e
+			// }
+			// expect(error && error.toString()).toMatch(/Error thrown in secondary/)
 
-		// 	error = null
-		// 	const secondaryFunctionReject = () => {
-		// 		return Promise.reject('Reject in secondary')
-		// 	}
-		// 	try {
-		// 		let second: any = await threaded.callFunction(() => {
-		// 			return secondaryFunctionReject
-		// 		})
-		// 		await second('second')
-		// 	} catch (e) {
-		// 		error = e
-		// 	}
-		// 	expect(error && error.toString()).toMatch(/Reject in secondary/)
-		// })
+			// error = null
+			// const secondaryFunctionReject = async () => {
+			// 	return Promise.reject('Reject in secondary')
+			// }
+			// try {
+			// 	let second: any = await threaded.callFunction(async () => {
+			// 		return secondaryFunctionReject
+			// 	})
+			// 	await second('second')
+			// } catch (e) {
+			// 	error = e
+			// }
+			// expect(error && error.toString()).toMatch(/Reject in secondary/)
+		})
 		test('logging', async () => {
 			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
@@ -611,27 +611,26 @@ const getTests = (disableMultithreading: boolean) => {
 				expect(mockLog.mock.calls[0]).toEqual(['', 'aa', 'bb'])
 			}
 		})
-		// test('EventEmitter', async () => {
-		// 	let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
+		test('EventEmitter', async () => {
+			let threaded 	= await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH, 'TestClass', [], { disableMultithreading })
 
-		// 	const eventListener0 = jest.fn()
-		// 	const eventListener1 = jest.fn()
-		// 	await threaded.on('event0', eventListener0)
-		// 	await threaded.on('event1', eventListener1)
+			const eventListener0 = jest.fn()
+			const eventListener1 = jest.fn()
+			await threaded.on('event0', eventListener0)
+			await threaded.on('event1', eventListener1)
 
-		// 	await threaded.emitMessage('event0', 'a')
-		// 	await threaded.emitMessage('event1', 'b')
+			await threaded.emitMessage('event0', 'a')
+			await threaded.emitMessage('event1', 'b')
 
-		// 	expect(eventListener0).toHaveBeenCalledTimes(1)
-		// 	expect(eventListener0).toHaveBeenCalledWith('a')
-		// 	expect(eventListener1).toHaveBeenCalledTimes(1)
-		// 	expect(eventListener1).toHaveBeenCalledWith('b')
+			expect(eventListener0).toHaveBeenCalledTimes(1)
+			expect(eventListener0).toHaveBeenCalledWith('a')
+			expect(eventListener1).toHaveBeenCalledTimes(1)
+			expect(eventListener1).toHaveBeenCalledWith('b')
 
-		// 	let self = await threaded.getSelf()
+			let self = await threaded.getSelf()
+			expect(self).toEqual(threaded)
 
-		// 	expect(self).toEqual(threaded)
-
-		// })
+		})
 		// test('import typescript', async () => {
 		// 	let threaded = await threadedClass<TestClass, typeof TestClass>(TESTCLASS_PATH_UNSYNCED, 'TestClass', [], { disableMultithreading })
 

--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -182,45 +182,10 @@ const getTests = (disableMultithreading: boolean) => {
 			await threaded.setWindows(['west', 'south'])
 			expect(await threaded.getWindows('')).toHaveLength(2)
 
-		// 	// Public property:
-		// 	original.windows = ['a','b','c','d']
-		// 	expect(original.windows).toEqual(['a','b','c','d'])
-		// 	//
-		// 	// @ts-ignore this technically works, though the typings do not:
-		// 	threaded.windows = ['a','b','c','d']
-		// 	expect(await threaded.windows).toEqual(['a','b','c','d'])
-
 			// Method to get private property:
 			expect(await original.getRooms()).toHaveLength(1)
 			//
 			expect(await threaded.getRooms()).toHaveLength(1)
-
-		// 	// Getter to get private property:
-		// 	expect(original.getterRooms).toHaveLength(1)
-		// 	//
-		// 	expect(await threaded.getterRooms).toHaveLength(1)
-
-		// 	// Private property that has both a getter and a setter:
-		// 	original.lamps = 91
-		// 	expect(original.lamps).toEqual(91)
-		// 	//
-		// 	// @ts-ignore this technically works, though the typings do not:
-		// 	threaded.lamps = 91
-		// 	expect(await threaded.lamps).toEqual(91)
-
-		// 	// Private property that only has getter:
-		// 	expect(original.readonly).toEqual(42)
-		// 	// original.readonly = 3 // not allowed according to types (which is correct)
-		// 	//
-		// 	expect(await threaded.readonly).toEqual(42)
-
-		// 	// Private property that only has setter:
-		// 	original.writeonly = 13
-		// 	expect(original.writeonly).toEqual(undefined)
-		// 	//
-		// 	// @ts-ignore this technically works, though the typings do not:
-		// 	threaded.writeonly = 13
-		// 	expect(await threaded.writeonly).toEqual(undefined)
 
 			await ThreadedClassManager.destroy(threaded)
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,5 @@
+// import { EventEmitter } from 'events'
+
 // TODO: change this as Variadic types are implemented in TS
 // https://github.com/Microsoft/TypeScript/issues/5453
 export type ReturnType<T> = T extends (...args: any[]) => infer R ? R : any
@@ -27,3 +29,107 @@ export interface ThreadedClassConfig {
 	instanceName?: string
 
 }
+
+// interface DontWantThis2 extends EventEmitter {
+// }
+// interface DontWantThis extends EventEmitter {
+// 	blah (): number
+// }
+
+// interface WantThis {
+// 	blah (): Promise<number>
+// }
+
+// interface NotAllowed {
+// 	a: null // TODO - this will break soonish
+// }
+
+// class IgnoreThisClass { // TODO - fix this
+// }
+
+export type BasicTypes = void | undefined | null | number | string | Buffer | boolean
+export type ReturnableTypes = BasicTypes | { [key: string]: TransferableTypes } | Array<TransferableTypes>
+export type TransferableTypes = ReturnableTypes | Promise<TransferableTypes>
+export type TransferableParameters = TransferableTypes | ((...args: TransferableTypes[]) => Promise<TransferableTypes>)
+
+// type MakePromise<T extends Function> = (ReturnType<T> extends TransferableTypes ? Promise<T> : never) // TODO Maybe we dont want to enforce returning a promise for this?
+
+// type MustReturnPromise<T extends Function> = (ReturnType<T> extends TransferableTypes ? T : never) // TODO Maybe we dont want to enforce returning a promise for this?
+// type MustReturnPromise<T extends Function> = (ReturnType<T> extends Promise<TransferableTypes> ? T : never)
+// type OtherOrMustReturnPromise<T extends Function | TransferableTypes> = T extends Function ? MustReturnPromise<T> : T // What was this for?
+// type ValidateType<T> = T extends TransferableTypes ? T : never
+
+// TODO - the types of these params dont look strict at all?
+// type Func0<T extends Function> = T extends () => infer R ? MustReturnPromise<() => R> : never
+// type Func1<T extends Function> = T extends (arg1: infer A1) => infer R ? MustReturnPromise<(arg1: A1) => R> : never
+// type Func2<T extends Function> = T extends (arg1: infer A1, arg2: infer A2) => infer R ? MustReturnPromise<(arg1: A1, arg2: A2) => R> : never
+// type FuncN<T extends Function> = T extends (...args: infer A) => infer R ? MustReturnPromise<(...args: A) => R> : never
+// type SomeFunc<T extends Function> = T extends (...args: TransferableTypes[]) => unknown ? Func0<T> | Func1<T> | Func2<T> | FuncN<T> : never
+// export type EnforceFunctionValidity<T> = T extends Function ? SomeFunc<T> : T
+
+export type EnforceTypeValidity<T> = T extends TransferableTypes ? T : never
+export type EnforceTypes<T> = {
+	[K in keyof T]: EnforceTypeValidity<T[K]>
+}
+
+
+type ArgsAAAA<T extends (...args: any) => any> = T extends (...args: infer K) => any ? K : never
+type ReturnTypeIsPromise<T> = T extends Promise<ReturnableTypes> ? T : never
+type FunctionValidateArgs<T extends Function> = T extends (...args: infer K) => infer R ? (...args: EnforceTypes<K>) => ReturnTypeIsPromise<R> : never
+type FunctionEnsureNotNever<T extends Function> = ReturnType<T> extends never ? never: T
+
+export type ArgsAAAAb = ArgsAAAA<(a: string, b: () => Function) => Promise<void>>
+// export const faaa: Func1<() => Promise<void>> = () => Promise.resolve()
+export type Abcd = EnforceTypes<ArgsAAAAb>
+export type asdsad = FunctionEnsureNotNever<FunctionValidateArgs<() => void>>
+export type asdsad2 = FunctionEnsureNotNever<FunctionValidateArgs<(a: Object) => Promise<void>>>
+
+export type ValidatedClass<T> = { [P in keyof T]: T[P] extends Function ? FunctionEnsureNotNever<FunctionValidateArgs<T[P]>> : never }
+
+// type Callable<T extends (...args: any[]) => any> = T
+// export const f: Callable<(a: never) => number> = (_a) => 5
+
+// export type ValidatedClass<T> = { [P in keyof T]: T[P] extends Function ? Func1<T[P]> : string }
+
+
+// function Something2<T extends Function> (_obj: EnforceFunctionValidity<T>) {
+// 	return 5
+// }
+
+// Something2<() => number>(() => 5)
+// Something2<() => Promise<Array<NotAllowed>>>(() => Promise.resolve([{}]))
+// Something2<() => Promise<Array<number>>>(() => Promise.resolve([6]))
+// Something2<() => Promise<number>>(() => Promise.resolve(5))
+// Something2<(a: number) => Promise<number>>((_a: number) => Promise.resolve(5))
+// Something2<(a: number) => Promise<Buffer>>((_a: number) => Promise.resolve(Buffer.from('4')))
+// Something2<(a: Buffer) => Promise<number>>((_a: Buffer) => Promise.resolve(5))
+// Something2<(a: NotAllowed) => Promise<number>>((_a: NotAllowed) => Promise.resolve(5))
+// Something2<(a: IgnoreThisClass) => Promise<number>>((_a: IgnoreThisClass) => Promise.resolve(5))
+// Something2<(a: number) => Promise<IgnoreThisClass>>((_a: number) => Promise.resolve(new IgnoreThisClass()))
+// Something2<(a: (b: number) => number) => Promise<number>>((_b: (_a: number) => number) => Promise.resolve(5))
+
+
+// // type Func2<T extends Function> = T extends (arg1: infer U1, arg2: infer U2) => infer R ? CheckFunctionReturnsPromise<(arg1: EnforceValidity<U1>, arg2: EnforceValidity<U2>) => R> : string
+// // const a: Required<WantThis>['blah'] = () => Promise.resolve(5)
+// // const b: Required<DontWantThis>['blah'] = () => Promise.resolve(5)
+// // console.log(a, b)
+
+// function Something<T> (_obj: ValidatedClass<T>) {
+// 	return 5
+// }
+// Something<DontWantThis2>({} as any as DontWantThis2)
+// Something<DontWantThis>({} as any as DontWantThis)
+// Something<WantThis>({} as any as WantThis)
+
+// interface DontWantThis3 {
+// 	blah (ab: () => number): Promise<number>
+// }
+
+// interface WantThis3 {
+// 	blah (ab: number): Promise<number>
+// }
+
+// // // export type WT3a = Required<WantThis3>
+// // // export type DWT3a = Required<DontWantThis3>
+// Something<DontWantThis3>({} as any as DontWantThis3)
+// Something<WantThis3>({} as any as WantThis3)

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,3 @@
-// TODO: change this as Variadic types are implemented in TS
-// https://github.com/Microsoft/TypeScript/issues/5453
-export type ReturnType<T> = T extends (...args: any[]) => infer R ? R : any
-
 // export type ThreadedClass<T> = ValidatedClass<T>
 // Note: We want to use the raw function definitions whenever possible, as that means we keep any generics and so the api remains the same
 export type ThreadedClass<T> = { [P in keyof T]: T[P] extends Function ? T[P] : never }
@@ -25,7 +21,10 @@ export interface ThreadedClassConfig {
 }
 
 /** This describes the types that are supported to be transferred either as a parameter or a return type */
-export type TransferableTypes = void | undefined | null | number | string | Buffer | boolean | { [key: string]: TransferableTypes } | Array<TransferableTypes> | Promise<TransferableTypes>
+type BasicTypes = void | undefined | null | number | string | Buffer | boolean
+export type ReturnTypes = BasicTypes | { [key: string]: ReturnTypes } | Array<ReturnTypes> | ((...args: ReturnTypes[]) => Promise<ReturnTypes>)
+export type TransferableTypes = ReturnTypes | { [key: string]: TransferableTypes } | Array<TransferableTypes> | Promise<TransferableTypes> | ((...args: TransferableTypes[]) => Promise<TransferableTypes>)
+
 // export type TransferableParameters = TransferableTypes | ((...args: TransferableTypes[]) => Promise<TransferableTypes>)
 
 /** Ensure that each property in this set are allowed */
@@ -36,10 +35,26 @@ type EnsureTypes<T> = {
 /** Ensure that a given type is a promise that contains something supported */
 type EnsureTypeIsPromise<T> = T extends Promise<TransferableTypes> ? T : never
 /** Ensure that the type is a function, with allowed parameter and return types */
-type FunctionValidateArgs<T extends Function> = T extends (...args: infer K) => infer R ? (...args: EnsureTypes<K>) => EnsureTypeIsPromise<R> : never
+type FunctionValidateArgs<T extends (...args: any) => any> = T extends (...args: infer K) => infer R ? EnsureFunctionParametersNotNever<(...args: EnsureTypes<K>) => EnsureTypeIsPromise<R>> : never
 /** Ensure that the type is a function, which does not return type never */
-type FunctionEnsureNotNever<T extends Function> = ReturnType<T> extends never ? never: T
+type FunctionEnsureNotNever<T extends (...args: any) => any> = T extends (...args: any[]) => never ? never : T
+/** Ensure that one of the function parameters is not never. If it is, then wipe out the whole function */
+type EnsureFunctionParametersNotNever<T extends (...args: any) => any> = OmitByValueExact<Parameters<T>, never> extends MapToKeyTypes<Parameters<T>> ? T : never
 
 /** This is a validator that turns anything unsupported into never */
-// TODO - property getters/setters?
-export type ValidatedClass<T> = { [P in keyof T]: T[P] extends Function ? FunctionEnsureNotNever<FunctionValidateArgs<T[P]>> : never }
+export type ValidatedClass<T> = { [P in keyof T]: T[P] extends (...args: any) => any ? FunctionEnsureNotNever<FunctionValidateArgs<T[P]>> : never }
+
+// To match the output of OmitByValueExact to allow for comparison
+type MapToKeyTypes<T> = Pick<T, { [Key in keyof T]-?: Key }[keyof T]>
+
+// From https://github.com/piotrwitek/utility-types/blob/2ae7412a9edf12f34fedbf594facf43cf04f7e32/src/mapped-types.ts#L257
+type OmitByValueExact<T, ValueType> = Pick<
+  T,
+  {
+	[Key in keyof T]-?: [ValueType] extends [T[Key]]
+	  ? [T[Key]] extends [ValueType]
+		? never
+		: Key
+	  : Key;
+  }[keyof T]
+>

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,7 +2,9 @@
 // https://github.com/Microsoft/TypeScript/issues/5453
 export type ReturnType<T> = T extends (...args: any[]) => infer R ? R : any
 
-export type ThreadedClass<T> = ValidatedClass<T>
+// export type ThreadedClass<T> = ValidatedClass<T>
+// Note: We want to use the raw function definitions whenever possible, as that means we keep any generics and so the api remains the same
+export type ThreadedClass<T> = { [P in keyof T]: T[P] extends Function ? T[P] : never }
 
 export interface ThreadedClassConfig {
 	/** A number between 0 - 1, how large part of a thread the instance takes up. For example; if set to 0.1, a thread will be re-used for up to 10 instances. */

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,16 +1,8 @@
-// import { EventEmitter } from 'events'
-
 // TODO: change this as Variadic types are implemented in TS
 // https://github.com/Microsoft/TypeScript/issues/5453
 export type ReturnType<T> = T extends (...args: any[]) => infer R ? R : any
 
-export type Promisify<T> = {
-	[K in keyof T]: PromisifyProperty<T[K]>
-}
-
-type PromisifyProperty<T> = T extends Function ? (...args: any[]) => Promise<ReturnType<T>> : Promise<T>
-
-export type ThreadedClass<T> = Promisify<T>
+export type ThreadedClass<T> = ValidatedClass<T>
 
 export interface ThreadedClassConfig {
 	/** A number between 0 - 1, how large part of a thread the instance takes up. For example; if set to 0.1, a thread will be re-used for up to 10 instances. */
@@ -30,106 +22,22 @@ export interface ThreadedClassConfig {
 
 }
 
-// interface DontWantThis2 extends EventEmitter {
-// }
-// interface DontWantThis extends EventEmitter {
-// 	blah (): number
-// }
+/** This describes the types that are supported to be transferred either as a parameter or a return type */
+export type TransferableTypes = void | undefined | null | number | string | Buffer | boolean | { [key: string]: TransferableTypes } | Array<TransferableTypes> | Promise<TransferableTypes>
+// export type TransferableParameters = TransferableTypes | ((...args: TransferableTypes[]) => Promise<TransferableTypes>)
 
-// interface WantThis {
-// 	blah (): Promise<number>
-// }
-
-// interface NotAllowed {
-// 	a: null // TODO - this will break soonish
-// }
-
-// class IgnoreThisClass { // TODO - fix this
-// }
-
-export type BasicTypes = void | undefined | null | number | string | Buffer | boolean
-export type ReturnableTypes = BasicTypes | { [key: string]: TransferableTypes } | Array<TransferableTypes>
-export type TransferableTypes = ReturnableTypes | Promise<TransferableTypes>
-export type TransferableParameters = TransferableTypes | ((...args: TransferableTypes[]) => Promise<TransferableTypes>)
-
-// type MakePromise<T extends Function> = (ReturnType<T> extends TransferableTypes ? Promise<T> : never) // TODO Maybe we dont want to enforce returning a promise for this?
-
-// type MustReturnPromise<T extends Function> = (ReturnType<T> extends TransferableTypes ? T : never) // TODO Maybe we dont want to enforce returning a promise for this?
-// type MustReturnPromise<T extends Function> = (ReturnType<T> extends Promise<TransferableTypes> ? T : never)
-// type OtherOrMustReturnPromise<T extends Function | TransferableTypes> = T extends Function ? MustReturnPromise<T> : T // What was this for?
-// type ValidateType<T> = T extends TransferableTypes ? T : never
-
-// TODO - the types of these params dont look strict at all?
-// type Func0<T extends Function> = T extends () => infer R ? MustReturnPromise<() => R> : never
-// type Func1<T extends Function> = T extends (arg1: infer A1) => infer R ? MustReturnPromise<(arg1: A1) => R> : never
-// type Func2<T extends Function> = T extends (arg1: infer A1, arg2: infer A2) => infer R ? MustReturnPromise<(arg1: A1, arg2: A2) => R> : never
-// type FuncN<T extends Function> = T extends (...args: infer A) => infer R ? MustReturnPromise<(...args: A) => R> : never
-// type SomeFunc<T extends Function> = T extends (...args: TransferableTypes[]) => unknown ? Func0<T> | Func1<T> | Func2<T> | FuncN<T> : never
-// export type EnforceFunctionValidity<T> = T extends Function ? SomeFunc<T> : T
-
-export type EnforceTypeValidity<T> = T extends TransferableTypes ? T : never
-export type EnforceTypes<T> = {
-	[K in keyof T]: EnforceTypeValidity<T[K]>
+/** Ensure that each property in this set are allowed */
+type EnsureTypes<T> = {
+	[K in keyof T]: T[K] extends TransferableTypes ? T[K] : never
 }
 
-
-type ArgsAAAA<T extends (...args: any) => any> = T extends (...args: infer K) => any ? K : never
-type ReturnTypeIsPromise<T> = T extends Promise<ReturnableTypes> ? T : never
-type FunctionValidateArgs<T extends Function> = T extends (...args: infer K) => infer R ? (...args: EnforceTypes<K>) => ReturnTypeIsPromise<R> : never
+/** Ensure that a given type is a promise that contains something supported */
+type EnsureTypeIsPromise<T> = T extends Promise<TransferableTypes> ? T : never
+/** Ensure that the type is a function, with allowed parameter and return types */
+type FunctionValidateArgs<T extends Function> = T extends (...args: infer K) => infer R ? (...args: EnsureTypes<K>) => EnsureTypeIsPromise<R> : never
+/** Ensure that the type is a function, which does not return type never */
 type FunctionEnsureNotNever<T extends Function> = ReturnType<T> extends never ? never: T
 
-export type ArgsAAAAb = ArgsAAAA<(a: string, b: () => Function) => Promise<void>>
-// export const faaa: Func1<() => Promise<void>> = () => Promise.resolve()
-export type Abcd = EnforceTypes<ArgsAAAAb>
-export type asdsad = FunctionEnsureNotNever<FunctionValidateArgs<() => void>>
-export type asdsad2 = FunctionEnsureNotNever<FunctionValidateArgs<(a: Object) => Promise<void>>>
-
+/** This is a validator that turns anything unsupported into never */
+// TODO - property getters/setters?
 export type ValidatedClass<T> = { [P in keyof T]: T[P] extends Function ? FunctionEnsureNotNever<FunctionValidateArgs<T[P]>> : never }
-
-// type Callable<T extends (...args: any[]) => any> = T
-// export const f: Callable<(a: never) => number> = (_a) => 5
-
-// export type ValidatedClass<T> = { [P in keyof T]: T[P] extends Function ? Func1<T[P]> : string }
-
-
-// function Something2<T extends Function> (_obj: EnforceFunctionValidity<T>) {
-// 	return 5
-// }
-
-// Something2<() => number>(() => 5)
-// Something2<() => Promise<Array<NotAllowed>>>(() => Promise.resolve([{}]))
-// Something2<() => Promise<Array<number>>>(() => Promise.resolve([6]))
-// Something2<() => Promise<number>>(() => Promise.resolve(5))
-// Something2<(a: number) => Promise<number>>((_a: number) => Promise.resolve(5))
-// Something2<(a: number) => Promise<Buffer>>((_a: number) => Promise.resolve(Buffer.from('4')))
-// Something2<(a: Buffer) => Promise<number>>((_a: Buffer) => Promise.resolve(5))
-// Something2<(a: NotAllowed) => Promise<number>>((_a: NotAllowed) => Promise.resolve(5))
-// Something2<(a: IgnoreThisClass) => Promise<number>>((_a: IgnoreThisClass) => Promise.resolve(5))
-// Something2<(a: number) => Promise<IgnoreThisClass>>((_a: number) => Promise.resolve(new IgnoreThisClass()))
-// Something2<(a: (b: number) => number) => Promise<number>>((_b: (_a: number) => number) => Promise.resolve(5))
-
-
-// // type Func2<T extends Function> = T extends (arg1: infer U1, arg2: infer U2) => infer R ? CheckFunctionReturnsPromise<(arg1: EnforceValidity<U1>, arg2: EnforceValidity<U2>) => R> : string
-// // const a: Required<WantThis>['blah'] = () => Promise.resolve(5)
-// // const b: Required<DontWantThis>['blah'] = () => Promise.resolve(5)
-// // console.log(a, b)
-
-// function Something<T> (_obj: ValidatedClass<T>) {
-// 	return 5
-// }
-// Something<DontWantThis2>({} as any as DontWantThis2)
-// Something<DontWantThis>({} as any as DontWantThis)
-// Something<WantThis>({} as any as WantThis)
-
-// interface DontWantThis3 {
-// 	blah (ab: () => number): Promise<number>
-// }
-
-// interface WantThis3 {
-// 	blah (ab: number): Promise<number>
-// }
-
-// // // export type WT3a = Required<WantThis3>
-// // // export type DWT3a = Required<DontWantThis3>
-// Something<DontWantThis3>({} as any as DontWantThis3)
-// Something<WantThis3>({} as any as WantThis3)

--- a/src/threadedClass.ts
+++ b/src/threadedClass.ts
@@ -18,9 +18,8 @@ import {
 	MessageCallbackConstr
 } from './internalApi'
 import {
-	ThreadedClass,
 	ThreadedClassConfig,
-	ValidatedClass
+	ThreadedClass
 } from './api'
 import { ThreadedClassManagerInternal, ChildInstance, Child } from './manager'
 import { isBrowser, browserSupportsWebWorkers } from './lib'
@@ -34,7 +33,7 @@ type CtorArgs<CtorT extends new (...args: any) => any> = CtorT extends new (...a
  * @param orgExport Name of export in module
  * @param constructorArgs An array of arguments to be fed into the class constructor
  */
-export function threadedClass<T extends ValidatedClass<T>, TCtor extends new (...args: any) => T> (
+export function threadedClass<T extends ThreadedClass<T>, TCtor extends new (...args: any) => T> (
 	orgModule: string,
 	orgExport: string,
 	constructorArgs: CtorArgs<TCtor>,

--- a/src/threadedClass.ts
+++ b/src/threadedClass.ts
@@ -19,7 +19,8 @@ import {
 } from './internalApi'
 import {
 	ThreadedClass,
-	ThreadedClassConfig
+	ThreadedClassConfig,
+	ValidatedClass
 } from './api'
 import { ThreadedClassManagerInternal, ChildInstance, Child } from './manager'
 import { isBrowser, browserSupportsWebWorkers } from './lib'
@@ -33,7 +34,7 @@ type CtorArgs<CtorT extends new (...args: any) => any> = CtorT extends new (...a
  * @param orgExport Name of export in module
  * @param constructorArgs An array of arguments to be fed into the class constructor
  */
-export function threadedClass<T, TCtor extends new (...args: any) => T> (
+export function threadedClass<T extends ValidatedClass<T>, TCtor extends new (...args: any) => T> (
 	orgModule: string,
 	orgExport: string,
 	constructorArgs: CtorArgs<TCtor>,

--- a/src/threadedClass.ts
+++ b/src/threadedClass.ts
@@ -19,7 +19,8 @@ import {
 } from './internalApi'
 import {
 	ThreadedClassConfig,
-	ThreadedClass
+	ThreadedClass,
+	ValidatedClass
 } from './api'
 import { ThreadedClassManagerInternal, ChildInstance, Child } from './manager'
 import { isBrowser, browserSupportsWebWorkers } from './lib'
@@ -33,7 +34,7 @@ type CtorArgs<CtorT extends new (...args: any) => any> = CtorT extends new (...a
  * @param orgExport Name of export in module
  * @param constructorArgs An array of arguments to be fed into the class constructor
  */
-export function threadedClass<T extends ThreadedClass<T>, TCtor extends new (...args: any) => T> (
+export function threadedClass<T extends ValidatedClass<T>, TCtor extends new (...args: any) => T> (
 	orgModule: string,
 	orgExport: string,
 	constructorArgs: CtorArgs<TCtor>,

--- a/test-lib/event.js
+++ b/test-lib/event.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.a = exports.CallbackClass = void 0;
+class CallbackClass {
+    // async basicFcn (cb: () => number) {
+    // 	// An example function that is not aware it might want to be run in a threadedClass
+    // 	return cb() + 5
+    // }
+    async promiseFcn(cb) {
+        // This function is safe for threaded class, as its callback returns a promise
+        return await cb() + 5;
+    }
+}
+exports.CallbackClass = CallbackClass;
+exports.a = new CallbackClass();

--- a/test-lib/event.ts
+++ b/test-lib/event.ts
@@ -1,0 +1,15 @@
+import type { ValidatedClass } from '..'
+
+export class CallbackClass {
+	// async basicFcn (cb: () => number) {
+	// 	// An example function that is not aware it might want to be run in a threadedClass
+	// 	return cb() + 5
+	// }
+
+	async promiseFcn (cb: () => Promise<number>) {
+		// This function is safe for threaded class, as its callback returns a promise
+		return await cb() + 5
+	}
+}
+
+export const a: ValidatedClass<CallbackClass> = new CallbackClass()

--- a/test-lib/house.js
+++ b/test-lib/house.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-// import { EventEmitter } from 'events'
+exports.House = exports.EventEmitter2 = void 0;
 const Emittery = require("emittery");
 const uuid = require("uuid");
 class EventEmitter2 {
@@ -12,7 +12,7 @@ class EventEmitter2 {
     on(event, listener) {
         const unsubId = uuid.v4();
         this.unubscribeFunctions[unsubId] = this.emittery.on(event, listener);
-        return unsubId;
+        return Promise.resolve(unsubId);
     }
     // once(event: string | symbol, listener: (...args: any[]) => void): this;
     // prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -29,6 +29,9 @@ class EventEmitter2 {
     }
 }
 exports.EventEmitter2 = EventEmitter2;
+// export type TS = ValidatedClass<EventEmitter2>
+// type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T]
+// export type tstsdf = FunctionPropertyNames<EventEmitter2>
 // function fib (num: number) {
 // 	let result = 0
 // 	if (num < 2) {
@@ -49,19 +52,19 @@ class House extends EventEmitter2 {
         this.windows = windows;
         this._rooms = rooms;
     }
-    // public returnValue<T> (value: T): T {
-    // 	return value
-    // }
-    getWindows(_a) {
+    async returnValue(value) {
+        return value;
+    }
+    async getWindows(_a) {
         if (_a) {
             return [_a, ...this.windows];
         }
         return this.windows;
     }
-    setWindows(windows) {
+    async setWindows(windows) {
         return this.windows = windows;
     }
-    getRooms() {
+    async getRooms() {
         return this._rooms;
     }
     // public get getterRooms () {
@@ -85,6 +88,17 @@ class House extends EventEmitter2 {
     // }
     doEmit(str) {
         return this.emit(str);
+    }
+    callCallback(d, cb) {
+        return new Promise((resolve, reject) => {
+            cb(d + ',child')
+                .then((result) => {
+                resolve(result + ',child2');
+            })
+                .catch((err) => {
+                reject(err);
+            });
+        });
     }
 }
 exports.House = House;

--- a/test-lib/house.js
+++ b/test-lib/house.js
@@ -32,15 +32,16 @@ exports.EventEmitter2 = EventEmitter2;
 // export type TS = ValidatedClass<EventEmitter2>
 // type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T]
 // export type tstsdf = FunctionPropertyNames<EventEmitter2>
-// function fib (num: number) {
-// 	let result = 0
-// 	if (num < 2) {
-// 		result = num
-// 	} else {
-// 		result = fib(num - 1) + fib(num - 2)
-// 	}
-// 	return result
-// }
+function fib(num) {
+    let result = 0;
+    if (num < 2) {
+        result = num;
+    }
+    else {
+        result = fib(num - 1) + fib(num - 2);
+    }
+    return result;
+}
 class House extends EventEmitter2 {
     // private _lamps: number = 0
     // private _readonly: number = 42
@@ -83,9 +84,9 @@ class House extends EventEmitter2 {
     // 	this._writeonly = this._writeonly
     // 	this._writeonly = value
     // }
-    // public slowFib (num: number) {
-    // 	return fib(num)
-    // }
+    async slowFib(num) {
+        return fib(num);
+    }
     doEmit(str) {
         return this.emit(str);
     }

--- a/test-lib/house.js
+++ b/test-lib/house.js
@@ -43,9 +43,6 @@ function fib(num) {
     return result;
 }
 class House extends EventEmitter2 {
-    // private _lamps: number = 0
-    // private _readonly: number = 42
-    // private _writeonly: number = 0
     constructor(windows, rooms) {
         super();
         this.windows = [];
@@ -68,22 +65,6 @@ class House extends EventEmitter2 {
     async getRooms() {
         return this._rooms;
     }
-    // public get getterRooms () {
-    // 	return this._rooms
-    // }
-    // public set lamps (l: number) {
-    // 	this._lamps = l
-    // }
-    // public get lamps () {
-    // 	return this._lamps
-    // }
-    // public get readonly () {
-    // 	return this._readonly
-    // }
-    // public set writeonly (value: number) {
-    // 	this._writeonly = this._writeonly
-    // 	this._writeonly = value
-    // }
     async slowFib(num) {
         return fib(num);
     }

--- a/test-lib/house.js
+++ b/test-lib/house.js
@@ -1,30 +1,57 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const events_1 = require("events");
-function fib(num) {
-    let result = 0;
-    if (num < 2) {
-        result = num;
+// import { EventEmitter } from 'events'
+const Emittery = require("emittery");
+const uuid = require("uuid");
+class EventEmitter2 {
+    constructor() {
+        this.emittery = new Emittery();
+        this.unubscribeFunctions = {};
     }
-    else {
-        result = fib(num - 1) + fib(num - 2);
+    // addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    on(event, listener) {
+        const unsubId = uuid.v4();
+        this.unubscribeFunctions[unsubId] = this.emittery.on(event, listener);
+        return unsubId;
     }
-    return result;
+    // once(event: string | symbol, listener: (...args: any[]) => void): this;
+    // prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    // prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    // removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    // off(event: string | symbol, listener: (...args: any[]) => void): this;
+    // removeAllListeners(event?: string | symbol): this;
+    // setMaxListeners(n: number): this;
+    // getMaxListeners(): number;
+    // listeners(event: string | symbol): Function[];
+    // rawListeners(event: string | symbol): Function[];
+    emit(event, ...args) {
+        return this.emittery.emit(event, ...args);
+    }
 }
-class House extends events_1.EventEmitter {
+exports.EventEmitter2 = EventEmitter2;
+// function fib (num: number) {
+// 	let result = 0
+// 	if (num < 2) {
+// 		result = num
+// 	} else {
+// 		result = fib(num - 1) + fib(num - 2)
+// 	}
+// 	return result
+// }
+class House extends EventEmitter2 {
+    // private _lamps: number = 0
+    // private _readonly: number = 42
+    // private _writeonly: number = 0
     constructor(windows, rooms) {
         super();
         this.windows = [];
         this._rooms = [];
-        this._lamps = 0;
-        this._readonly = 42;
-        this._writeonly = 0;
         this.windows = windows;
         this._rooms = rooms;
     }
-    returnValue(value) {
-        return value;
-    }
+    // public returnValue<T> (value: T): T {
+    // 	return value
+    // }
     getWindows(_a) {
         if (_a) {
             return [_a, ...this.windows];
@@ -37,38 +64,27 @@ class House extends events_1.EventEmitter {
     getRooms() {
         return this._rooms;
     }
-    get getterRooms() {
-        return this._rooms;
-    }
-    set lamps(l) {
-        this._lamps = l;
-    }
-    get lamps() {
-        return this._lamps;
-    }
-    get readonly() {
-        return this._readonly;
-    }
-    set writeonly(value) {
-        this._writeonly = this._writeonly;
-        this._writeonly = value;
-    }
-    slowFib(num) {
-        return fib(num);
-    }
+    // public get getterRooms () {
+    // 	return this._rooms
+    // }
+    // public set lamps (l: number) {
+    // 	this._lamps = l
+    // }
+    // public get lamps () {
+    // 	return this._lamps
+    // }
+    // public get readonly () {
+    // 	return this._readonly
+    // }
+    // public set writeonly (value: number) {
+    // 	this._writeonly = this._writeonly
+    // 	this._writeonly = value
+    // }
+    // public slowFib (num: number) {
+    // 	return fib(num)
+    // }
     doEmit(str) {
-        this.emit(str);
-    }
-    callCallback(d, cb) {
-        return new Promise((resolve, reject) => {
-            cb(d + ',child')
-                .then((result) => {
-                resolve(result + ',child2');
-            })
-                .catch((err) => {
-                reject(err);
-            });
-        });
+        return this.emit(str);
     }
 }
 exports.House = House;

--- a/test-lib/house.ts
+++ b/test-lib/house.ts
@@ -1,64 +1,112 @@
-import { EventEmitter } from 'events'
+// import { EventEmitter } from 'events'
+import Emittery = require('emittery')
+import uuid = require('uuid')
+import { ValidatedClass } from '../src/api'
 
-function fib (num: number) {
-	let result = 0
-	if (num < 2) {
-		result = num
-	} else {
-		result = fib(num - 1) + fib(num - 2)
+// import { EventEmitter } from 'events'
+
+// TODO - deduplicate this
+export type BasicTypes = void | undefined | null | number | string | Buffer | boolean
+export type TransferableTypes = BasicTypes | { [key: string]: TransferableTypes } | Array<TransferableTypes> | Promise<TransferableTypes>
+export type TransferableParameters = TransferableTypes | ((...args: TransferableTypes[]) => Promise<TransferableTypes>)
+
+export type HandlerId = string
+export class EventEmitter2 {
+	private emittery: Emittery
+	private unubscribeFunctions: { [key: string]: Emittery.UnsubscribeFn }
+
+	constructor () {
+		this.emittery = new Emittery()
+		this.unubscribeFunctions = {}
 	}
-	return result
-}
-export class House extends EventEmitter {
 
-	public windows: Array<string> = []
+	// addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+	on (event: string, listener: () => Promise<void>): Promise<HandlerId> { // listener: (...args: TransferableTypes[]) => Promise<void>
+		const unsubId = uuid.v4()
+		this.unubscribeFunctions[unsubId] = this.emittery.on(event, listener)
+		return Promise.resolve(unsubId)
+	}
+	// once(event: string | symbol, listener: (...args: any[]) => void): this;
+	// prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+	// prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+	// removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+	// off(event: string | symbol, listener: (...args: any[]) => void): this;
+	// removeAllListeners(event?: string | symbol): this;
+	// setMaxListeners(n: number): this;
+	// getMaxListeners(): number;
+	// listeners(event: string | symbol): Function[];
+	// rawListeners(event: string | symbol): Function[];
+	emit (event: string, ...args: TransferableTypes[]): Promise<void> {
+		return this.emittery.emit(event, ...args)
+	}
+	// eventNames(): Array<string | symbol>;
+	// listenerCount(type: string | symbol): number;
+}
+
+export type TS = ValidatedClass<EventEmitter2>
+
+// type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T]
+// export type tstsdf = FunctionPropertyNames<EventEmitter2>
+
+// function fib (num: number) {
+// 	let result = 0
+// 	if (num < 2) {
+// 		result = num
+// 	} else {
+// 		result = fib(num - 1) + fib(num - 2)
+// 	}
+// 	return result
+// }
+export class House extends EventEmitter2 {
+
+	private windows: Array<string> = []
 	private _rooms: Array<string> = []
-	private _lamps: number = 0
-	private _readonly: number = 42
-	private _writeonly: number = 0
+	// private _lamps: number = 0
+	// private _readonly: number = 42
+	// private _writeonly: number = 0
 	constructor (windows: Array<string>, rooms: Array<string>) {
 		super()
 		this.windows = windows
 		this._rooms = rooms
 	}
-	public returnValue<T> (value: T): T {
-		return value
-	}
-	public getWindows (_a: string) {
+	// public returnValue<T> (value: T): T {
+	// 	return value
+	// }
+	public async getWindows (_a: string): Promise<string[]> {
 		if (_a) {
 			return [_a, ...this.windows]
 		}
 		return this.windows
 	}
-	public setWindows (windows: Array<string>) {
+	public async setWindows (windows: Array<string>): Promise<string[]> {
 		return this.windows = windows
 	}
-	public getRooms () {
+	public async getRooms (): Promise<string[]> {
 		return this._rooms
 	}
-	public get getterRooms () {
-		return this._rooms
-	}
-	public set lamps (l: number) {
-		this._lamps = l
-	}
-	public get lamps () {
-		return this._lamps
-	}
-	public get readonly () {
-		return this._readonly
-	}
-	public set writeonly (value: number) {
-		this._writeonly = this._writeonly
-		this._writeonly = value
-	}
-	public slowFib (num: number) {
-		return fib(num)
-	}
+	// public get getterRooms () {
+	// 	return this._rooms
+	// }
+	// public set lamps (l: number) {
+	// 	this._lamps = l
+	// }
+	// public get lamps () {
+	// 	return this._lamps
+	// }
+	// public get readonly () {
+	// 	return this._readonly
+	// }
+	// public set writeonly (value: number) {
+	// 	this._writeonly = this._writeonly
+	// 	this._writeonly = value
+	// }
+	// public slowFib (num: number) {
+	// 	return fib(num)
+	// }
 	public doEmit (str: string) {
-		this.emit(str)
+		return this.emit(str)
 	}
-	public callCallback (d: string, cb: (d2: string) => Promise<string>) {
+	public callCallback (d: string, cb: (d2: string) => Promise<string>): Promise<string> {
 		return new Promise((resolve, reject) => {
 			cb(d + ',child')
 			.then((result) => {

--- a/test-lib/house.ts
+++ b/test-lib/house.ts
@@ -1,11 +1,11 @@
 import Emittery = require('emittery')
 import uuid = require('uuid')
-import type { ValidatedClass, TransferableTypes } from '../src/api'
+import type { TransferableTypes } from './tmp'
 
 export type HandlerId = string
 export class EventEmitter2 {
-	private emittery: Emittery
-	private unubscribeFunctions: { [key: string]: Emittery.UnsubscribeFn }
+	private readonly emittery: Emittery
+	private readonly unubscribeFunctions: { [key: string]: Emittery.UnsubscribeFn }
 
 	constructor () {
 		this.emittery = new Emittery()
@@ -35,7 +35,7 @@ export class EventEmitter2 {
 	// listenerCount(type: string | symbol): number;
 }
 
-export type TS = ValidatedClass<EventEmitter2>
+// export type TS = ValidatedClass<EventEmitter2>
 
 // type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T]
 // export type tstsdf = FunctionPropertyNames<EventEmitter2>
@@ -61,9 +61,9 @@ export class House extends EventEmitter2 {
 		this.windows = windows
 		this._rooms = rooms
 	}
-	// public returnValue<T> (value: T): T {
-	// 	return value
-	// }
+	public async returnValue<T extends TransferableTypes> (value: T): Promise<T> {
+		return value
+	}
 	public async getWindows (_a: string): Promise<string[]> {
 		if (_a) {
 			return [_a, ...this.windows]

--- a/test-lib/house.ts
+++ b/test-lib/house.ts
@@ -40,15 +40,15 @@ export class EventEmitter2 {
 // type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T]
 // export type tstsdf = FunctionPropertyNames<EventEmitter2>
 
-// function fib (num: number) {
-// 	let result = 0
-// 	if (num < 2) {
-// 		result = num
-// 	} else {
-// 		result = fib(num - 1) + fib(num - 2)
-// 	}
-// 	return result
-// }
+function fib (num: number) {
+	let result = 0
+	if (num < 2) {
+		result = num
+	} else {
+		result = fib(num - 1) + fib(num - 2)
+	}
+	return result
+}
 export class House extends EventEmitter2 {
 
 	private windows: Array<string> = []
@@ -92,9 +92,9 @@ export class House extends EventEmitter2 {
 	// 	this._writeonly = this._writeonly
 	// 	this._writeonly = value
 	// }
-	// public slowFib (num: number) {
-	// 	return fib(num)
-	// }
+	public async slowFib (num: number) {
+		return fib(num)
+	}
 	public doEmit (str: string) {
 		return this.emit(str)
 	}

--- a/test-lib/house.ts
+++ b/test-lib/house.ts
@@ -1,14 +1,6 @@
-// import { EventEmitter } from 'events'
 import Emittery = require('emittery')
 import uuid = require('uuid')
-import { ValidatedClass } from '../src/api'
-
-// import { EventEmitter } from 'events'
-
-// TODO - deduplicate this
-export type BasicTypes = void | undefined | null | number | string | Buffer | boolean
-export type TransferableTypes = BasicTypes | { [key: string]: TransferableTypes } | Array<TransferableTypes> | Promise<TransferableTypes>
-export type TransferableParameters = TransferableTypes | ((...args: TransferableTypes[]) => Promise<TransferableTypes>)
+import type { ValidatedClass, TransferableTypes } from '../src/api'
 
 export type HandlerId = string
 export class EventEmitter2 {

--- a/test-lib/house.ts
+++ b/test-lib/house.ts
@@ -53,9 +53,6 @@ export class House extends EventEmitter2 {
 
 	private windows: Array<string> = []
 	private _rooms: Array<string> = []
-	// private _lamps: number = 0
-	// private _readonly: number = 42
-	// private _writeonly: number = 0
 	constructor (windows: Array<string>, rooms: Array<string>) {
 		super()
 		this.windows = windows
@@ -76,22 +73,6 @@ export class House extends EventEmitter2 {
 	public async getRooms (): Promise<string[]> {
 		return this._rooms
 	}
-	// public get getterRooms () {
-	// 	return this._rooms
-	// }
-	// public set lamps (l: number) {
-	// 	this._lamps = l
-	// }
-	// public get lamps () {
-	// 	return this._lamps
-	// }
-	// public get readonly () {
-	// 	return this._readonly
-	// }
-	// public set writeonly (value: number) {
-	// 	this._writeonly = this._writeonly
-	// 	this._writeonly = value
-	// }
 	public async slowFib (num: number) {
 		return fib(num)
 	}

--- a/test-lib/rename.js
+++ b/test-lib/rename.js
@@ -1,4 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.AlmostTestClass = void 0;
 const testClass_1 = require("./testClass");
-exports.AlmostTestClass = testClass_1.TestClass;
+Object.defineProperty(exports, "AlmostTestClass", { enumerable: true, get: function () { return testClass_1.TestClass; } });

--- a/test-lib/testClass.js
+++ b/test-lib/testClass.js
@@ -22,27 +22,27 @@ class TestClass extends house_1.EventEmitter2 {
     async returnParam1() {
         return this.param1;
     }
-    // public async callFunction<T extends TransferableTypes> (fcn: (...args: TransferableTypes[]) => Promise<T>, ...args: TransferableTypes[]): Promise<T> {
-    // 	return fcn(...args)
-    // }
-    // public setParam1 (val: any) {
-    // 	return this.param1 = val
-    // }
-    callParam1(...args) {
+    async callFunction(fcn, ...args) {
+        return fcn(...args);
+    }
+    async setParam1(val) {
+        return this.param1 = val;
+    }
+    async callParam1(...args) {
         return this.param1(...args);
     }
-    // public callParam1Function<T> (...args: any[]): T {
-    // 	return this.param1.fcn(...args)
-    // }
+    async callParam1Function(...args) {
+        return this.param1.fcn(...args);
+    }
     // public callChildFunction<T> (obj: { fcn: (...args: any[]) => T }, ...args: any[]): T {
     // 	return obj.fcn(...args)
     // }
-    // public throwError () {
-    // 	throw new Error('Error thrown')
-    // }
-    // public throwErrorString () {
-    // 	throw 'Error string thrown' // tslint:disable-line
-    // }
+    async throwError() {
+        throw new Error('Error thrown');
+    }
+    async throwErrorString() {
+        throw 'Error string thrown'; // tslint:disable-line
+    }
     async exitProcess(time) {
         if (!time) {
             process.exit(1);
@@ -79,6 +79,9 @@ class TestClass extends house_1.EventEmitter2 {
     }
     emitMessage(name, val) {
         return this.emit(name, val);
+    }
+    async getSelf() {
+        return this;
     }
 }
 exports.TestClass = TestClass;

--- a/test-lib/testClass.js
+++ b/test-lib/testClass.js
@@ -1,38 +1,36 @@
 "use strict";
-// import { EventEmitter } from 'events'
-// import { TransferableTypes } from '../src'
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.TestClass = void 0;
 const house_1 = require("./house");
 class TestClass extends house_1.EventEmitter2 {
-    // private param1: any
     // set Param1 (val: any) {
     // 	this.param1 = val
     // }
-    constructor(_param1) {
+    constructor(param1) {
         super();
         // circular reference, so that function that return self (such as EventEmitter.on can have trouble)
         this.myself = this;
         this.myself = this.myself;
-        // this.param1 = param1
+        this.param1 = param1;
     }
-    getId() {
+    async getId() {
         return 'abc';
     }
-    returnValue(value) {
+    async returnValue(value) {
         return value;
     }
-    // public returnParam1 () {
-    // 	return this.param1
-    // }
-    // public callFunction<T> (fcn: (...args: any[]) => T, ...args: any[]): T {
+    async returnParam1() {
+        return this.param1;
+    }
+    // public async callFunction<T extends TransferableTypes> (fcn: (...args: TransferableTypes[]) => Promise<T>, ...args: TransferableTypes[]): Promise<T> {
     // 	return fcn(...args)
     // }
     // public setParam1 (val: any) {
     // 	return this.param1 = val
     // }
-    // public callParam1<T> (...args: any[]): T {
-    // 	return this.param1(...args)
-    // }
+    callParam1(...args) {
+        return this.param1(...args);
+    }
     // public callParam1Function<T> (...args: any[]): T {
     // 	return this.param1.fcn(...args)
     // }
@@ -45,7 +43,7 @@ class TestClass extends house_1.EventEmitter2 {
     // public throwErrorString () {
     // 	throw 'Error string thrown' // tslint:disable-line
     // }
-    exitProcess(time) {
+    async exitProcess(time) {
         if (!time) {
             process.exit(1);
         }
@@ -55,10 +53,10 @@ class TestClass extends house_1.EventEmitter2 {
             }, time);
         }
     }
-    logSomething(...args) {
+    async logSomething(...args) {
         console.log(...args);
     }
-    freeze() {
+    async freeze() {
         while (true) {
             // do nothing, but freeze
         }
@@ -70,7 +68,7 @@ class TestClass extends house_1.EventEmitter2 {
             }, waitTime);
         });
     }
-    getCircular(val) {
+    async getCircular(val) {
         let o = {
             a: 1,
             b: 2,

--- a/test-lib/testClass.js
+++ b/test-lib/testClass.js
@@ -1,16 +1,19 @@
 "use strict";
+// import { EventEmitter } from 'events'
+// import { TransferableTypes } from '../src'
 Object.defineProperty(exports, "__esModule", { value: true });
-const events_1 = require("events");
-class TestClass extends events_1.EventEmitter {
-    constructor(param1) {
+const house_1 = require("./house");
+class TestClass extends house_1.EventEmitter2 {
+    // private param1: any
+    // set Param1 (val: any) {
+    // 	this.param1 = val
+    // }
+    constructor(_param1) {
         super();
         // circular reference, so that function that return self (such as EventEmitter.on can have trouble)
         this.myself = this;
         this.myself = this.myself;
-        this.param1 = param1;
-    }
-    set Param1(val) {
-        this.param1 = val;
+        // this.param1 = param1
     }
     getId() {
         return 'abc';
@@ -18,30 +21,30 @@ class TestClass extends events_1.EventEmitter {
     returnValue(value) {
         return value;
     }
-    returnParam1() {
-        return this.param1;
-    }
-    callFunction(fcn, ...args) {
-        return fcn(...args);
-    }
-    setParam1(val) {
-        return this.param1 = val;
-    }
-    callParam1(...args) {
-        return this.param1(...args);
-    }
-    callParam1Function(...args) {
-        return this.param1.fcn(...args);
-    }
-    callChildFunction(obj, ...args) {
-        return obj.fcn(...args);
-    }
-    throwError() {
-        throw new Error('Error thrown');
-    }
-    throwErrorString() {
-        throw 'Error string thrown'; // tslint:disable-line
-    }
+    // public returnParam1 () {
+    // 	return this.param1
+    // }
+    // public callFunction<T> (fcn: (...args: any[]) => T, ...args: any[]): T {
+    // 	return fcn(...args)
+    // }
+    // public setParam1 (val: any) {
+    // 	return this.param1 = val
+    // }
+    // public callParam1<T> (...args: any[]): T {
+    // 	return this.param1(...args)
+    // }
+    // public callParam1Function<T> (...args: any[]): T {
+    // 	return this.param1.fcn(...args)
+    // }
+    // public callChildFunction<T> (obj: { fcn: (...args: any[]) => T }, ...args: any[]): T {
+    // 	return obj.fcn(...args)
+    // }
+    // public throwError () {
+    // 	throw new Error('Error thrown')
+    // }
+    // public throwErrorString () {
+    // 	throw 'Error string thrown' // tslint:disable-line
+    // }
     exitProcess(time) {
         if (!time) {
             process.exit(1);
@@ -77,10 +80,7 @@ class TestClass extends events_1.EventEmitter {
         return o;
     }
     emitMessage(name, val) {
-        this.emit(name, val);
-    }
-    getSelf() {
-        return this;
+        return this.emit(name, val);
     }
 }
 exports.TestClass = TestClass;

--- a/test-lib/testClass.js
+++ b/test-lib/testClass.js
@@ -3,9 +3,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.TestClass = void 0;
 const house_1 = require("./house");
 class TestClass extends house_1.EventEmitter2 {
-    // set Param1 (val: any) {
-    // 	this.param1 = val
-    // }
     constructor(param1) {
         super();
         // circular reference, so that function that return self (such as EventEmitter.on can have trouble)
@@ -34,7 +31,7 @@ class TestClass extends house_1.EventEmitter2 {
     async callParam1Function(...args) {
         return this.param1.fcn(...args);
     }
-    // public callChildFunction<T> (obj: { fcn: (...args: any[]) => T }, ...args: any[]): T {
+    // public async callChildFunction<T> (obj: { fcn: (...args: any[]) => T }, ...args: any[]): Promise<T> {
     // 	return obj.fcn(...args)
     // }
     async throwError() {

--- a/test-lib/testClass.ts
+++ b/test-lib/testClass.ts
@@ -30,27 +30,27 @@ export class TestClass extends EventEmitter2 {
 	public async returnParam1 () {
 		return this.param1
 	}
-	// public async callFunction<T extends TransferableTypes> (fcn: (...args: TransferableTypes[]) => Promise<T>, ...args: TransferableTypes[]): Promise<T> {
-	// 	return fcn(...args)
-	// }
-	// public setParam1 (val: any) {
-	// 	return this.param1 = val
-	// }
-	public callParam1<T extends ReturnTypes> (...args: TransferableTypes[]): Promise<T> {
+	public async callFunction<T extends TransferableTypes> (fcn: (...args: TransferableTypes[]) => Promise<T>, ...args: TransferableTypes[]): Promise<T> {
+		return fcn(...args)
+	}
+	public async setParam1 (val: any) {
+		return this.param1 = val
+	}
+	public async callParam1<T extends ReturnTypes> (...args: TransferableTypes[]): Promise<T> {
 		return this.param1(...args)
 	}
-	// public callParam1Function<T> (...args: any[]): T {
-	// 	return this.param1.fcn(...args)
-	// }
+	public async callParam1Function<T extends ReturnTypes> (...args: any[]): Promise<T> {
+		return this.param1.fcn(...args)
+	}
 	// public callChildFunction<T> (obj: { fcn: (...args: any[]) => T }, ...args: any[]): T {
 	// 	return obj.fcn(...args)
 	// }
-	// public throwError () {
-	// 	throw new Error('Error thrown')
-	// }
-	// public throwErrorString () {
-	// 	throw 'Error string thrown' // tslint:disable-line
-	// }
+	public async throwError () {
+		throw new Error('Error thrown')
+	}
+	public async throwErrorString () {
+		throw 'Error string thrown' // tslint:disable-line
+	}
 	public async exitProcess (time: number): Promise<void> {
 		if (!time) {
 			process.exit(1)
@@ -87,7 +87,7 @@ export class TestClass extends EventEmitter2 {
 	public emitMessage (name: string, val: any) {
 		return this.emit(name, val)
 	}
-	// public getSelf (): TestClass {
-	// 	return this
-	// }
+	public async getSelf (): Promise<any> {
+		return this
+	}
 }

--- a/test-lib/testClass.ts
+++ b/test-lib/testClass.ts
@@ -1,7 +1,6 @@
-// import { EventEmitter } from 'events'
-// import { TransferableTypes } from '../src'
 
-import { EventEmitter2, BasicTypes } from './house'
+import { EventEmitter2 } from './house'
+import type { TransferableTypes } from '../src/api'
 
 export class TestClass extends EventEmitter2 {
 
@@ -25,7 +24,7 @@ export class TestClass extends EventEmitter2 {
 	public async getId (): Promise<string> {
 		return 'abc'
 	}
-	public async returnValue<T extends BasicTypes> (value: T): Promise<T> {
+	public async returnValue<T extends TransferableTypes> (value: T): Promise<T> {
 		return value
 	}
 	public async returnParam1 () {
@@ -37,7 +36,7 @@ export class TestClass extends EventEmitter2 {
 	// public setParam1 (val: any) {
 	// 	return this.param1 = val
 	// }
-	public callParam1<T extends BasicTypes> (...args: BasicTypes[]): Promise<T> {
+	public callParam1<T extends TransferableTypes> (...args: TransferableTypes[]): Promise<T> {
 		return this.param1(...args)
 	}
 	// public callParam1Function<T> (...args: any[]): T {

--- a/test-lib/testClass.ts
+++ b/test-lib/testClass.ts
@@ -1,6 +1,6 @@
 
 import { EventEmitter2 } from './house'
-import type { TransferableTypes } from '../src/api'
+import type { TransferableTypes, ReturnTypes } from './tmp'
 
 export class TestClass extends EventEmitter2 {
 
@@ -36,7 +36,7 @@ export class TestClass extends EventEmitter2 {
 	// public setParam1 (val: any) {
 	// 	return this.param1 = val
 	// }
-	public callParam1<T extends TransferableTypes> (...args: TransferableTypes[]): Promise<T> {
+	public callParam1<T extends ReturnTypes> (...args: TransferableTypes[]): Promise<T> {
 		return this.param1(...args)
 	}
 	// public callParam1Function<T> (...args: any[]): T {

--- a/test-lib/testClass.ts
+++ b/test-lib/testClass.ts
@@ -8,10 +8,6 @@ export class TestClass extends EventEmitter2 {
 
 	private param1: any
 
-	// set Param1 (val: any) {
-	// 	this.param1 = val
-	// }
-
 	constructor (param1?: any) {
 		super()
 
@@ -42,7 +38,7 @@ export class TestClass extends EventEmitter2 {
 	public async callParam1Function<T extends ReturnTypes> (...args: any[]): Promise<T> {
 		return this.param1.fcn(...args)
 	}
-	// public callChildFunction<T> (obj: { fcn: (...args: any[]) => T }, ...args: any[]): T {
+	// public async callChildFunction<T> (obj: { fcn: (...args: any[]) => T }, ...args: any[]): Promise<T> {
 	// 	return obj.fcn(...args)
 	// }
 	public async throwError () {

--- a/test-lib/testClass.ts
+++ b/test-lib/testClass.ts
@@ -1,14 +1,17 @@
-import { EventEmitter } from 'events'
+// import { EventEmitter } from 'events'
+// import { TransferableTypes } from '../src'
 
-export class TestClass extends EventEmitter {
+import { EventEmitter2, BasicTypes } from './house'
+
+export class TestClass extends EventEmitter2 {
 
 	private myself: TestClass
 
 	private param1: any
 
-	set Param1 (val: any) {
-		this.param1 = val
-	}
+	// set Param1 (val: any) {
+	// 	this.param1 = val
+	// }
 
 	constructor (param1?: any) {
 		super()
@@ -19,37 +22,37 @@ export class TestClass extends EventEmitter {
 
 		this.param1 = param1
 	}
-	public getId (): string {
+	public async getId (): Promise<string> {
 		return 'abc'
 	}
-	public returnValue<T> (value: T): T {
+	public async returnValue<T extends BasicTypes> (value: T): Promise<T> {
 		return value
 	}
-	public returnParam1 () {
+	public async returnParam1 () {
 		return this.param1
 	}
-	public callFunction<T> (fcn: (...args: any[]) => T, ...args: any[]): T {
-		return fcn(...args)
-	}
-	public setParam1 (val: any) {
-		return this.param1 = val
-	}
-	public callParam1<T> (...args: any[]): T {
+	// public async callFunction<T extends TransferableTypes> (fcn: (...args: TransferableTypes[]) => Promise<T>, ...args: TransferableTypes[]): Promise<T> {
+	// 	return fcn(...args)
+	// }
+	// public setParam1 (val: any) {
+	// 	return this.param1 = val
+	// }
+	public callParam1<T extends BasicTypes> (...args: BasicTypes[]): Promise<T> {
 		return this.param1(...args)
 	}
-	public callParam1Function<T> (...args: any[]): T {
-		return this.param1.fcn(...args)
-	}
-	public callChildFunction<T> (obj: { fcn: (...args: any[]) => T }, ...args: any[]): T {
-		return obj.fcn(...args)
-	}
-	public throwError () {
-		throw new Error('Error thrown')
-	}
-	public throwErrorString () {
-		throw 'Error string thrown' // tslint:disable-line
-	}
-	public exitProcess (time: number): void {
+	// public callParam1Function<T> (...args: any[]): T {
+	// 	return this.param1.fcn(...args)
+	// }
+	// public callChildFunction<T> (obj: { fcn: (...args: any[]) => T }, ...args: any[]): T {
+	// 	return obj.fcn(...args)
+	// }
+	// public throwError () {
+	// 	throw new Error('Error thrown')
+	// }
+	// public throwErrorString () {
+	// 	throw 'Error string thrown' // tslint:disable-line
+	// }
+	public async exitProcess (time: number): Promise<void> {
 		if (!time) {
 			process.exit(1)
 		} else {
@@ -58,22 +61,22 @@ export class TestClass extends EventEmitter {
 			}, time)
 		}
 	}
-	public logSomething (...args: any[]) {
+	public async logSomething (...args: any[]) {
 		console.log(...args)
 	}
-	public freeze () {
+	public async freeze () {
 		while (true) {
 			// do nothing, but freeze
 		}
 	}
-	public waitReply (waitTime: number, reply: any) {
+	public waitReply<T extends string | number> (waitTime: number, reply: T): Promise<T> {
 		return new Promise((resolve) => {
 			setTimeout(() => {
 				resolve(reply)
 			}, waitTime)
 		})
 	}
-	public getCircular (val: any) {
+	public async getCircular (val: any) {
 		let o: any = {
 			a: 1,
 			b: 2,
@@ -83,9 +86,9 @@ export class TestClass extends EventEmitter {
 		return o
 	}
 	public emitMessage (name: string, val: any) {
-		this.emit(name, val)
+		return this.emit(name, val)
 	}
-	public getSelf (): TestClass {
-		return this
-	}
+	// public getSelf (): TestClass {
+	// 	return this
+	// }
 }

--- a/test-lib/tmp.js
+++ b/test-lib/tmp.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/test-lib/tmp.ts
+++ b/test-lib/tmp.ts
@@ -1,2 +1,4 @@
-export type TransferableTypes = void | undefined | null | number | string | Buffer | boolean | { [key: string]: TransferableTypes } | Array<TransferableTypes> | Promise<TransferableTypes>
-export type ReturnTypes = void | undefined | null | number | string | Buffer | boolean | { [key: string]: TransferableTypes } | Array<TransferableTypes>
+
+type BasicTypes = void | undefined | null | number | string | Buffer | boolean
+export type ReturnTypes = BasicTypes | { [key: string]: ReturnTypes } | Array<ReturnTypes> | ((...args: ReturnTypes[]) => Promise<ReturnTypes>)
+export type TransferableTypes = ReturnTypes | { [key: string]: TransferableTypes } | Array<TransferableTypes> | Promise<TransferableTypes> | ((...args: TransferableTypes[]) => Promise<TransferableTypes>)

--- a/test-lib/tmp.ts
+++ b/test-lib/tmp.ts
@@ -1,0 +1,2 @@
+export type TransferableTypes = void | undefined | null | number | string | Buffer | boolean | { [key: string]: TransferableTypes } | Array<TransferableTypes> | Promise<TransferableTypes>
+export type ReturnTypes = void | undefined | null | number | string | Buffer | boolean | { [key: string]: TransferableTypes } | Array<TransferableTypes>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,26 +2,26 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.1.tgz#d5481c5095daa1c57e16e54c6f9198443afb49ff"
-  integrity sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.3.tgz#324bcfd8d35cd3d47dae18cde63d752086435e9a"
+  integrity sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==
   dependencies:
-    "@babel/highlight" "^7.10.1"
+    "@babel/highlight" "^7.10.3"
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
-  version "7.10.2"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.2.tgz#bd6786046668a925ac2bd2fd95b579b92a23b36a"
-  integrity sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.3.tgz#73b0e8ddeec1e3fdd7a2de587a60e17c440ec77e"
+  integrity sha512-5YqWxYE3pyhIi84L84YcwjeEgS+fa7ZjK6IBVGTjDVfm64njkR2lfDhVR5OudLk8x2GK59YoSyVv+L/03k1q9w==
   dependencies:
-    "@babel/code-frame" "^7.10.1"
-    "@babel/generator" "^7.10.2"
+    "@babel/code-frame" "^7.10.3"
+    "@babel/generator" "^7.10.3"
     "@babel/helper-module-transforms" "^7.10.1"
     "@babel/helpers" "^7.10.1"
-    "@babel/parser" "^7.10.2"
-    "@babel/template" "^7.10.1"
-    "@babel/traverse" "^7.10.1"
-    "@babel/types" "^7.10.2"
+    "@babel/parser" "^7.10.3"
+    "@babel/template" "^7.10.3"
+    "@babel/traverse" "^7.10.3"
+    "@babel/types" "^7.10.3"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.1"
@@ -31,45 +31,45 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.10.1", "@babel/generator@^7.10.2":
-  version "7.10.2"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.2.tgz#0fa5b5b2389db8bfdfcc3492b551ee20f5dd69a9"
-  integrity sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==
+"@babel/generator@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.3.tgz#32b9a0d963a71d7a54f5f6c15659c3dbc2a523a5"
+  integrity sha512-drt8MUHbEqRzNR0xnF8nMehbY11b1SDkRw03PSNH/3Rb2Z35oxkddVSi3rcaak0YJQ86PCuE7Qx1jSFhbLNBMA==
   dependencies:
-    "@babel/types" "^7.10.2"
+    "@babel/types" "^7.10.3"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
 
-"@babel/helper-function-name@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz#92bd63829bfc9215aca9d9defa85f56b539454f4"
-  integrity sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==
+"@babel/helper-function-name@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.3.tgz#79316cd75a9fa25ba9787ff54544307ed444f197"
+  integrity sha512-FvSj2aiOd8zbeqijjgqdMDSyxsGHaMt5Tr0XjQsGKHD3/1FP3wksjnLAWzxw7lvXiej8W1Jt47SKTZ6upQNiRw==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.10.1"
-    "@babel/template" "^7.10.1"
-    "@babel/types" "^7.10.1"
+    "@babel/helper-get-function-arity" "^7.10.3"
+    "@babel/template" "^7.10.3"
+    "@babel/types" "^7.10.3"
 
-"@babel/helper-get-function-arity@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz#7303390a81ba7cb59613895a192b93850e373f7d"
-  integrity sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==
+"@babel/helper-get-function-arity@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.3.tgz#3a28f7b28ccc7719eacd9223b659fdf162e4c45e"
+  integrity sha512-iUD/gFsR+M6uiy69JA6fzM5seno8oE85IYZdbVVEuQaZlEzMO2MXblh+KSPJgsZAUx0EEbWXU0yJaW7C9CdAVg==
   dependencies:
-    "@babel/types" "^7.10.1"
+    "@babel/types" "^7.10.3"
 
 "@babel/helper-member-expression-to-functions@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz#432967fd7e12a4afef66c4687d4ca22bc0456f15"
-  integrity sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.3.tgz#bc3663ac81ac57c39148fef4c69bf48a77ba8dd6"
+  integrity sha512-q7+37c4EPLSjNb2NmWOjNwj0+BOyYlssuQ58kHEWk1Z78K5i8vTUsteq78HMieRPQSl/NtpQyJfdjt3qZ5V2vw==
   dependencies:
-    "@babel/types" "^7.10.1"
+    "@babel/types" "^7.10.3"
 
 "@babel/helper-module-imports@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz#dd331bd45bccc566ce77004e9d05fe17add13876"
-  integrity sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.3.tgz#766fa1d57608e53e5676f23ae498ec7a95e1b11a"
+  integrity sha512-Jtqw5M9pahLSUWA+76nhK9OG8nwYXzhQzVIGFoNaHnXF/r4l7kz4Fl0UAW7B6mqC5myoJiBP5/YQlXQTMfHI9w==
   dependencies:
-    "@babel/types" "^7.10.1"
+    "@babel/types" "^7.10.3"
 
 "@babel/helper-module-transforms@^7.10.1":
   version "7.10.1"
@@ -85,16 +85,16 @@
     lodash "^4.17.13"
 
 "@babel/helper-optimise-call-expression@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz#b4a1f2561870ce1247ceddb02a3860fa96d72543"
-  integrity sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.3.tgz#f53c4b6783093195b0f69330439908841660c530"
+  integrity sha512-kT2R3VBH/cnSz+yChKpaKRJQJWxdGoc6SjioRId2wkeV3bK0wLLioFpJROrX0U4xr/NmxSSAWT/9Ih5snwIIzg==
   dependencies:
-    "@babel/types" "^7.10.1"
+    "@babel/types" "^7.10.3"
 
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.1", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz#ec5a5cf0eec925b66c60580328b122c01230a127"
-  integrity sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.3.tgz#aac45cccf8bc1873b99a85f34bceef3beb5d3244"
+  integrity sha512-j/+j8NAWUTxOtx4LKHybpSClxHoq6I91DQ/mKgAXn5oNUPIUiGppjPIX3TDtJWPrdfP9Kfl7e4fgVMiQR9VE/g==
 
 "@babel/helper-replace-supers@^7.10.1":
   version "7.10.1"
@@ -121,10 +121,10 @@
   dependencies:
     "@babel/types" "^7.10.1"
 
-"@babel/helper-validator-identifier@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz#5770b0c1a826c4f53f5ede5e153163e0318e94b5"
-  integrity sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==
+"@babel/helper-validator-identifier@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz#60d9847f98c4cea1b279e005fdb7c28be5412d15"
+  integrity sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==
 
 "@babel/helpers@^7.10.1":
   version "7.10.1"
@@ -135,19 +135,19 @@
     "@babel/traverse" "^7.10.1"
     "@babel/types" "^7.10.1"
 
-"@babel/highlight@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.1.tgz#841d098ba613ba1a427a2b383d79e35552c38ae0"
-  integrity sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==
+"@babel/highlight@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.3.tgz#c633bb34adf07c5c13156692f5922c81ec53f28d"
+  integrity sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.10.1"
+    "@babel/helper-validator-identifier" "^7.10.3"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.10.1", "@babel/parser@^7.10.2":
-  version "7.10.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
-  integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
+"@babel/parser@^7.1.0", "@babel/parser@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.3.tgz#7e71d892b0d6e7d04a1af4c3c79d72c1f10f5315"
+  integrity sha512-oJtNJCMFdIMwXGmx+KxuaD7i3b8uS7TTFYW/FNG2BT8m+fmGHoiPYoH0Pe3gya07WuFmM5FCDIr1x0irkD/hyA==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -167,6 +167,13 @@
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.1.tgz#d5bc0645913df5b17ad7eda0fa2308330bde34c5"
   integrity sha512-Gf2Yx/iRs1JREDtVZ56OrjjgFHCaldpTnuy9BHla10qyVT3YkIIGEtoDWhyop0ksu1GvNjHIoYRBqm3zoR1jyQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.1"
+
+"@babel/plugin-syntax-import-meta@^7.8.3":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.1.tgz#3e59120ed8b3c2ccc5abb1cfc7aaa3ea01cd36b6"
+  integrity sha512-ypC4jwfIVF72og0dgvEcFRdOM2V9Qm1tu7RGmdZOlhsccyK0wisXmMObGuWEOd5jQ+K9wcIgSNftCpk2vkjUfQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
@@ -219,36 +226,36 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/template@^7.10.1", "@babel/template@^7.3.3":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.1.tgz#e167154a94cb5f14b28dc58f5356d2162f539811"
-  integrity sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==
+"@babel/template@^7.10.1", "@babel/template@^7.10.3", "@babel/template@^7.3.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.3.tgz#4d13bc8e30bf95b0ce9d175d30306f42a2c9a7b8"
+  integrity sha512-5BjI4gdtD+9fHZUsaxPHPNpwa+xRkDO7c7JbhYn2afvrkDu5SfAAbi9AIMXw2xEhO/BR35TqiW97IqNvCo/GqA==
   dependencies:
-    "@babel/code-frame" "^7.10.1"
-    "@babel/parser" "^7.10.1"
-    "@babel/types" "^7.10.1"
+    "@babel/code-frame" "^7.10.3"
+    "@babel/parser" "^7.10.3"
+    "@babel/types" "^7.10.3"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.1.tgz#bbcef3031e4152a6c0b50147f4958df54ca0dd27"
-  integrity sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.10.1", "@babel/traverse@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.3.tgz#0b01731794aa7b77b214bcd96661f18281155d7e"
+  integrity sha512-qO6623eBFhuPm0TmmrUFMT1FulCmsSeJuVGhiLodk2raUDFhhTECLd9E9jC4LBIWziqt4wgF6KuXE4d+Jz9yug==
   dependencies:
-    "@babel/code-frame" "^7.10.1"
-    "@babel/generator" "^7.10.1"
-    "@babel/helper-function-name" "^7.10.1"
+    "@babel/code-frame" "^7.10.3"
+    "@babel/generator" "^7.10.3"
+    "@babel/helper-function-name" "^7.10.3"
     "@babel/helper-split-export-declaration" "^7.10.1"
-    "@babel/parser" "^7.10.1"
-    "@babel/types" "^7.10.1"
+    "@babel/parser" "^7.10.3"
+    "@babel/types" "^7.10.3"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.10.1", "@babel/types@^7.10.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
-  version "7.10.2"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.2.tgz#30283be31cad0dbf6fb00bd40641ca0ea675172d"
-  integrity sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==
+"@babel/types@^7.0.0", "@babel/types@^7.10.1", "@babel/types@^7.10.3", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.3.tgz#6535e3b79fea86a6b09e012ea8528f935099de8e"
+  integrity sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.10.1"
+    "@babel/helper-validator-identifier" "^7.10.3"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -562,13 +569,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/callsites@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/callsites/-/callsites-3.0.0.tgz#81546cd5baddde92174622ef6ec7f110f05a8ddb"
-  integrity sha512-WBZUlj3+RvfQOrfGxqJvn/twli3TFyjtFBpVHCjHsO2aTpyaB7JabC1te081672Nwae1jUlFcQoVG9zK4ZV7VQ==
-  dependencies:
-    callsites "*"
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -587,9 +587,9 @@
     "@types/node" "*"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz#79d7a78bad4219f4c03d6557a1c72d9ca6ba62d5"
-  integrity sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
+  integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
 
 "@types/istanbul-lib-report@*":
   version "3.0.0"
@@ -606,18 +606,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^25.2.3":
-  version "25.2.3"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.3.tgz#33d27e4c4716caae4eced355097a47ad363fdcaf"
-  integrity sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==
+"@types/jest@^26.0.0":
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.0.tgz#a6d7573dffa9c68cbbdf38f2e0de26f159e11134"
+  integrity sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==
   dependencies:
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
-
-"@types/minimatch@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
-  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/minimist@^1.2.0":
   version "1.2.0"
@@ -625,14 +620,14 @@
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
 "@types/node@*":
-  version "14.0.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.11.tgz#61d4886e2424da73b7b25547f59fdcb534c165a3"
-  integrity sha512-lCvvI24L21ZVeIiyIUHZ5Oflv1hhHQ5E1S25IRlKIXaRkVgmXpJMI3wUJkmym2bTbCe+WoIibQnMVAU3FguaOg==
+  version "14.0.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
+  integrity sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==
 
 "@types/node@^12.12.5":
-  version "12.12.44"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.44.tgz#0d400a1453adcb359b133acceae4dd8bb0e0a159"
-  integrity sha512-jM6QVv0Sm5d3nW+nUD5jSzPcO6oPqboitSNcwgBay9hifVq/Rauq1PYnROnsmuw45JMBiTnsPAno0bKu2e2xrg==
+  version "12.12.47"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.47.tgz#5007b8866a2f9150de82335ca7e24dd1d59bdfb5"
+  integrity sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -649,10 +644,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/uuid@^3.4.6":
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.9.tgz#fcf01997bbc9f7c09ae5f91383af076d466594e1"
-  integrity sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==
+"@types/uuid@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.0.0.tgz#165aae4819ad2174a17476dbe66feebd549556c0"
+  integrity sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -697,9 +692,9 @@ acorn-node@^1.2.0, acorn-node@^1.3.0, acorn-node@^1.5.2, acorn-node@^1.6.1:
     xtend "^4.0.2"
 
 acorn-walk@^7.0.0, acorn-walk@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
-  integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
+  integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
 acorn@5.X, acorn@^5.0.3:
   version "5.7.4"
@@ -707,9 +702,9 @@ acorn@5.X, acorn@^5.0.3:
   integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
 acorn@^7.0.0, acorn@^7.1.1:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
-  integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
+  integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -1072,13 +1067,14 @@ babel-plugin-jest-hoist@^26.0.0:
     "@types/babel__traverse" "^7.0.6"
 
 babel-preset-current-node-syntax@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.2.tgz#fb4a4c51fe38ca60fede1dc74ab35eb843cb41d6"
-  integrity sha512-u/8cS+dEiK1SFILbOC8/rUI3ml9lboKuuMvZ/4aQnQmhecQAgPw5ew066C1ObnEAUmlx7dv/s2z52psWEtLNiw==
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz#b4b547acddbf963cba555ba9f9cbbb70bfd044da"
+  integrity sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==
   dependencies:
     "@babel/plugin-syntax-async-generators" "^7.8.4"
     "@babel/plugin-syntax-bigint" "^7.8.3"
     "@babel/plugin-syntax-class-properties" "^7.8.3"
+    "@babel/plugin-syntax-import-meta" "^7.8.3"
     "@babel/plugin-syntax-json-strings" "^7.8.3"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.8.3"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
@@ -1109,13 +1105,6 @@ bach@^1.0.0:
     async-done "^1.2.2"
     async-settle "^1.0.0"
     now-and-later "^2.0.0"
-
-backbone@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
-  integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
-  dependencies:
-    underscore ">=1.8.3"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1446,7 +1435,7 @@ cached-path-relative@^1.0.0, cached-path-relative@^1.0.2:
   resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.0.2.tgz#a13df4196d26776220cc3356eb147a52dba2c6db"
   integrity sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==
 
-callsites@*, callsites@^3.0.0, callsites@^3.1.0:
+callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
@@ -1541,9 +1530,9 @@ chalk@^3.0.0:
     supports-color "^7.1.0"
 
 chalk@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
-  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2479,9 +2468,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 elliptic@^6.0.0, elliptic@^6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
-  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -2819,12 +2808,12 @@ figures@3.1.0:
     escape-string-regexp "^1.0.5"
 
 file-type@^14.1.4:
-  version "14.6.1"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-14.6.1.tgz#156cf5de04649729469b2d527773df29b5eca051"
-  integrity sha512-h8TJ6Ff9UuhSOHr44Xh2J2r7Gg5ED8jNZKQ2XA2WyFCRum9qTcY3Qy1Q6mG5xMTeIT3IJcLlSReD4WEr/nL9vw==
+  version "14.6.2"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-14.6.2.tgz#5bf69c0d8c39de525d3d9de23d81a3b6e81cf69a"
+  integrity sha512-kSZTAJxPXBdBgJyoC7TexkBWoMI/D1Gas6aTtAn9VIRFwCehwiluGV5O8O2GwqO5zIqeEvXxEKl/xfcaAKB0Yg==
   dependencies:
     readable-web-to-node-stream "^2.0.0"
-    strtok3 "^6.0.0"
+    strtok3 "^6.0.3"
     token-types "^2.0.0"
     typedarray-to-buffer "^3.1.5"
 
@@ -3384,7 +3373,7 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
-handlebars@^4.7.2, handlebars@^4.7.6:
+handlebars@^4.7.6:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
@@ -3501,10 +3490,10 @@ highland@^3.0.0-beta.3:
   resolved "https://registry.yarnpkg.com/highland/-/highland-3.0.0-beta.10.tgz#e07869611de2109134c523e2479ef5af5334c112"
   integrity sha512-fBxAarP4g0AFWRKd+SJBWsKmkyw1WZdQZ1jjFSAVrxLXIhEo5NnEBy+rDEM695Z/i4/tP2lMYW6iuotStDFHYw==
 
-highlight.js@^9.17.1:
-  version "9.18.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
-  integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
+highlight.js@^10.0.0:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.1.1.tgz#691a2148a8d922bf12e52a294566a0d993b94c57"
+  integrity sha512-b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -4444,11 +4433,6 @@ jest@^26.0.1:
     import-local "^3.0.2"
     jest-cli "^26.0.1"
 
-jquery@^3.4.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4902,10 +4886,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.8.0:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
-  integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
+marked@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.0.0.tgz#d35784245a04871e5988a491e28867362e941693"
+  integrity sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==
 
 matchdep@^2.0.0:
   version "2.0.0"
@@ -6538,7 +6522,7 @@ shell-quote@^1.6.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@^0.8.3:
+shelljs@^0.8.3, shelljs@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
   integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
@@ -6985,10 +6969,10 @@ strip-url-auth@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-url-auth/-/strip-url-auth-1.0.1.tgz#22b0fa3a41385b33be3f331551bbb837fa0cd7ae"
   integrity sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=
 
-strtok3@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.2.tgz#b81443d4f98624e9429b1b37a44eac15fb379f0f"
-  integrity sha512-8/LNTW+SFsfUXbo0P/zNz5FqMVaKCZSZ3/aycaPw7l9RiNutj0XSLI9AcyJcLR+iIL/2FrpUHZxHfAzN7xisAA==
+strtok3@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.3.tgz#bc81e225c19a909eab86538ff3348c4b3b0553d3"
+  integrity sha512-/3RaYN9rW5WEYNHSvn081CgL4HziT027hfi5tsksbPfeWxi3BSLb8tolZDzpYU3I78/0ZqRiFpMDAqN2t4YShA==
   dependencies:
     "@tokenizer/token" "^0.1.1"
     "@types/debug" "^4.1.5"
@@ -7468,37 +7452,28 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.7.2.tgz#1e9896f920b58e6da0bba9d7e643738d02405a5a"
-  integrity sha512-fiFKlFO6VTqjcno8w6WpTsbCgXmfPHVjnLfYkmByZE7moaz+E2DSpAT+oHtDHv7E0BM5kAhPrHJELP2J2Y2T9A==
+typedoc-default-themes@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.10.1.tgz#eb27b7d689457c7ec843e47ec0d3e500581296a7"
+  integrity sha512-SuqAQI0CkwhqSJ2kaVTgl37cWs733uy9UGUqwtcds8pkFK8oRF4rZmCq+FXTGIb9hIUOu40rf5Kojg0Ha6akeg==
   dependencies:
-    backbone "^1.4.0"
-    jquery "^3.4.1"
     lunr "^2.3.8"
-    underscore "^1.9.1"
 
-typedoc@^0.16.0:
-  version "0.16.11"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.16.11.tgz#95f862c6eba78533edc9af7096d2295b718eddc1"
-  integrity sha512-YEa5i0/n0yYmLJISJ5+po6seYfJQJ5lQYcHCPF9ffTF92DB/TAZO/QrazX5skPHNPtmlIht5FdTXCM2kC7jQFQ==
+typedoc@^0.17.7:
+  version "0.17.7"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.17.7.tgz#70797401140403a5f91589ed3f4f24c03841bf7a"
+  integrity sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==
   dependencies:
-    "@types/minimatch" "3.0.3"
     fs-extra "^8.1.0"
-    handlebars "^4.7.2"
-    highlight.js "^9.17.1"
+    handlebars "^4.7.6"
+    highlight.js "^10.0.0"
     lodash "^4.17.15"
-    marked "^0.8.0"
+    lunr "^2.3.8"
+    marked "1.0.0"
     minimatch "^3.0.0"
     progress "^2.0.3"
-    shelljs "^0.8.3"
-    typedoc-default-themes "^0.7.2"
-    typescript "3.7.x"
-
-typescript@3.7.x:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+    shelljs "^0.8.4"
+    typedoc-default-themes "^0.10.1"
 
 typescript@~3.9.4:
   version "3.9.5"
@@ -7532,11 +7507,6 @@ undeclared-identifiers@^1.1.2:
     get-assigned-identifiers "^1.2.0"
     simple-concat "^1.0.0"
     xtend "^4.0.1"
-
-underscore@>=1.8.3, underscore@^1.9.1:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.10.2.tgz#73d6aa3668f3188e4adb0f1943bd12cfd7efaaaf"
-  integrity sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==
 
 undertaker-registry@^1.0.0:
   version "1.0.1"
@@ -7687,7 +7657,7 @@ util@~0.10.1:
   dependencies:
     inherits "2.0.3"
 
-uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -7696,6 +7666,11 @@ uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
+uuid@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
+  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
 
 v8-to-istanbul@^4.1.3:
   version "4.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,6 +649,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/uuid@^3.4.6":
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.9.tgz#fcf01997bbc9f7c09ae5f91383af076d466594e1"
+  integrity sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -2490,6 +2495,11 @@ email-addresses@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-3.1.0.tgz#cabf7e085cbdb63008a70319a74e6136188812fb"
   integrity sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==
+
+emittery@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.5.1.tgz#9fbbf57e9aecc258d727d78858a598eb05ea5c96"
+  integrity sha512-sYZXNHH9PhTfs98ROEFVC3bLiR8KSqXQsEHIwZ9J6H0RaQObC3JYq4G8IvDd0b45/LxfGKYBpmaUN4LiKytaNw==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -7323,10 +7333,15 @@ tslib@1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
   integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
 
-tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1:
+tslib@^1.10.0, tslib@^1.8.1:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
 
 tslint-config-standard@^9.0.0:
   version "9.0.0"
@@ -7485,10 +7500,10 @@ typescript@3.7.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
-typescript@~3.6.4:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
-  integrity sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==
+typescript@~3.9.4:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 uglify-js@^3.0.5, uglify-js@^3.1.4, uglify-js@^3.6.0:
   version "3.9.4"
@@ -7672,7 +7687,7 @@ util@~0.10.1:
   dependencies:
     inherits "2.0.3"
 
-uuid@^3.3.2:
+uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,15 +1503,6 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-casparcg-connection@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-3.0.1.tgz#6b43698651b6a4501424d0eb19b4b1b8f4ce3052"
-  integrity sha1-a0NphlG2pFAUJNDrGbSxuPTOMFI=
-  dependencies:
-    highland "^3.0.0-beta.3"
-    xml2js "^0.4.17"
-    xmlbuilder "^9.0.1"
-
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -3484,11 +3475,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
-
-highland@^3.0.0-beta.3:
-  version "3.0.0-beta.10"
-  resolved "https://registry.yarnpkg.com/highland/-/highland-3.0.0-beta.10.tgz#e07869611de2109134c523e2479ef5af5334c112"
-  integrity sha512-fBxAarP4g0AFWRKd+SJBWsKmkyw1WZdQZ1jjFSAVrxLXIhEo5NnEBy+rDEM695Z/i4/tP2lMYW6iuotStDFHYw==
 
 highlight.js@^10.0.0:
   version "10.1.1"
@@ -6409,11 +6395,6 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@>=0.6.0:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
 saxes@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
@@ -7952,24 +7933,6 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
-
-xml2js@^0.4.17:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
-
-xmlbuilder@^9.0.1:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
-
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Related: #20 

This completely overhauls how we handle the class type. Instead of mangling the class to be 'Promisey', we instead require that the original class operates in promises. This is needed because the following class will need code changes as the callback will instead return a `Promise<number>` not a `number`
```
export class CallbackClass {
	async basicFcn (cb: () => number) {
		return cb() + 5
	}
}
```

Also by doing this, we can very clearly whitelist what datatypes are allowed to be used, and using anything else will result in type errors.

Additionally, support for property getters/setters has been removed, as they do not translate properly, and end up with the setters wanting to be given a promise, and you cant await the set so could become a floating promise.

This does make it a very breaking change, as any class not specifically designed for this will not work.

### TODO
* [ ] Remove the code which handled getters/setters
* [ ] Review the code for other 'dead' bits (the changes so far only change the typings)
* [ ] Fix/remove the remaining disabled tests
* [ ] Finish implementing the `EventEmitter2` in house.ts and move it to be a core type for library consumers to use