### PR TITLE
fix: reuse callbacks where possible

### DIFF
--- a/src/__tests__/test.spec.ts
+++ b/src/__tests__/test.spec.ts
@@ -98,6 +98,14 @@ const getTests = (disableMultithreading: boolean) => {
 			await new Promise((resolve) => { setTimeout(resolve, 200) })
 			expect(onEvent).toHaveBeenCalledTimes(1)
 
+			onEvent.mockClear()
+			await threaded.removeListener('test', onEvent)
+
+			await threaded.doEmit('test')
+
+			await new Promise((resolve) => { setTimeout(resolve, 200) })
+			expect(onEvent).toHaveBeenCalledTimes(0)
+
 			await ThreadedClassManager.destroy(threaded)
 			expect(ThreadedClassManager.getThreadCount()).toEqual(0)
 		})

--- a/src/shared/sharedApi.ts
+++ b/src/shared/sharedApi.ts
@@ -234,6 +234,13 @@ export function encodeArguments (instance: any, callbacks: {[key: string]: Funct
 				if (typeof arg === 'string') return { type: ArgumentType.STRING, value: arg }
 				if (typeof arg === 'number') return { type: ArgumentType.NUMBER, value: arg }
 				if (typeof arg === 'function') {
+					// have we seen this one before?
+					for (const id in callbacks) {
+						if (callbacks[id] === arg) {
+							return { type: ArgumentType.FUNCTION, value: id + '' }
+						}
+					}
+					// new function, so add it to our list
 					const callbackId = argumentsCallbackId++
 					callbacks[callbackId + ''] = arg
 					return { type: ArgumentType.FUNCTION, value: callbackId + '' }


### PR DESCRIPTION
If a function is passed more than once we should make sure the remote end sees the same function as it saw the first time. This is needed to make event listeners detachable.

Currently the threadedclass library creates a new callback every time we pass a function, this means that when calling `myThreadedClass.removeListener('event', listener)` the function `listener` will not be the same as the one we used in `myThreadedClass.on('event', listener)`.