### PR TITLE
fix: only resolve error stack when needed.

### DIFF
--- a/src/parent-process/threadedClass.ts
+++ b/src/parent-process/threadedClass.ts
@@ -204,7 +204,7 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 							const fcn = (...args: any[]) => {
 								// An instance method is called by parent
 
-								const originalStack = 'Original stack:\n' + new Error().stack
+								const originalError = new Error()
 
 								if (!instance.child) return Promise.reject(new Error(`Instance ${instance.id} has been detached from child process`))
 
@@ -220,6 +220,7 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 											// Function result is returned from worker
 
 											if (err) {
+												const originalStack = 'Original stack:\n' + originalError.stack
 												if (typeof err === 'string') {
 													err += '\n' + originalStack
 												} else {


### PR DESCRIPTION
This PR makes a small modification to when an Error().stack is fetched (no changes in functionality).

In my local tests I can see a noticeable performance increase:

**Test file:**
``` typescript
import { threadedClass, ThreadedClassManager } from '../../src/index'

import { House } from '../../test-lib/house'
const HOUSE_PATH = '../../test-lib/house.js' // This is the path to the js-file (not a ts-file!) that contains the class

async function runExample () {
	// Create threaded instance of the class House:
	let c0 = await threadedClass<House, typeof House>(HOUSE_PATH, 'House', [[], []])
	let start = Date.now()

	const ps = []
	for (let i = 0; i < 1000; i++) {
		ps.push(c0.returnValue(0))

	}
	const p = Promise.all(ps)

	console.log('Sent in ', Date.now() - start)
	await p
	console.log('Done in ', Date.now() - start)

	// Clean up & close all threads:
	await ThreadedClassManager.destroyAll()
}
runExample()
.catch(console.log)

```

**Results, before the fix:**
```
Sent in  82
Done in  89
```

**Results, after the fix:**
```
Sent in  12
Done in  19
```


