### PR TITLE
fix: fatal error in stripSack

### DIFF
--- a/src/shared/lib.ts
+++ b/src/shared/lib.ts
@@ -50,7 +50,7 @@ export function stripStack (stack: string | undefined, matchLines: RegExp[]): st
 	for (let i = 0; i < stackLines.length; i++) {
 		let matching = false
 		for (const line of matchLines) {
-			if (stackLines[i].match(line)) {
+			if (stackLines[i] && stackLines[i].match(line)) {
 				if (matchIndex === -1) matchIndex = i
 				matching = true
 				i += 1


### PR DESCRIPTION
An error being thrown in a method was resulting in the whole child crashing 

```
{"level":"debug","message":"ERROR Cannot read properties of undefined (reading 'match')","stack":"TypeError: Cannot read properties of undefined (reading 'match')\n    at stripStack (/home/julus/Projects/sofietv/sofie-timeline-state-resolver/node_modules/threadedclass/dist/shared/lib.js:59:31)\n    at /home/julus/Projects/sofietv/sofie-timeline-state-resolver/node_modules/threadedclass/dist/child-process/worker.js:337:55"}
```