### PR TITLE
feat: callback garbage collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,6 @@ The loader can be overridden by defining the `THREADEDCLASS_WORKERTHREAD_LOADER`
 
 ## Known limitations
 * The to-be-threaded class must not be referencing any global variables, as the class is run in its own sandbox.
-* **No garbage-collection of callback-functions**
-    Currently, if you give a callback to a method (like so: `threaded.myMethod(() => {})`) a reference to the method will be stored indefinitely, because we cannot determine if the reference is valid in the child process.
 * There is a noticable delay when spawning a new thread, and since each thread is its own Node-process it uses up a few Megabytes of memory. If you intend to spawn many instances of a class, consider using the _threadUsage_ option (for example `threadUsage: 0.1` will put 10 instances in a thread before spawning a new).
 
 ## Under the hood

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -22,7 +22,7 @@
     "traceResolution": false,
     "pretty": true,
     "lib": [
-      "es6"
+      "ESNext"
     ],
     "types": [
       "node",

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.strict",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es2021",
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "../dist",
@@ -22,7 +22,7 @@
     "traceResolution": false,
     "pretty": true,
     "lib": [
-      "ESNext"
+      "ES2021"
     ],
     "types": [
       "node",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:all": "yarn build:main && gulp browserify",
     "build:test-lib": "tsc -p tsconfig.test-lib.json",
     "lint": "tslint --project tsconfig.json --config tslint.json",
-    "unit": "jest",
+    "unit": "node --expose-gc ./node_modules/jest/bin/jest.js",
     "test": "yarn lint && yarn unit",
     "test:integration": "yarn lint && jest --config=jest-integration.config.js",
     "watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "reset": "Delete all untracked files and reset the repo to the last commit"
   },
   "engines": {
-    "node": ">=8.0"
+    "node": ">=14.6.0"
   },
   "files": [
     "/dist",

--- a/src/child-process/worker.ts
+++ b/src/child-process/worker.ts
@@ -24,8 +24,9 @@ export abstract class Worker {
 	}
 	protected instanceHandles: {[instanceId: string]: InstanceHandle} = {}
 
-	private callbacks: {[key: string]: Function} = {}
-	private remoteFns: {[key: string]: (...args: any[]) => Promise<any>} = {}
+	private callbacks: {[key: string]: { fun: Function, count: number }} = {}
+	private remoteFns: {[key: string]: { ref: WeakRef<(...args: any[]) => Promise<any>>; count: number }} = {}
+	private finalizationRegistry = new FinalizationRegistry(this.finalizeRemoteFunction)
 
 	protected disabledMultithreading: boolean = false
 
@@ -84,13 +85,16 @@ export abstract class Worker {
 	private decodeArgumentsFromParent (handle: InstanceHandle, args: Array<ArgDefinition>) {
 		// Note: handle.instance could change if this was called for the constructor parameters, so it needs to be loose
 		return decodeArguments(() => handle.instance, args, (a: ArgDefinition) => {
-			const callbackId = a.value
+			const callbackId = a.value[0]
+			const count = a.value[1]
 
-			if (!this.remoteFns[callbackId]) {
-				this.remoteFns[callbackId] = ((...args: any[]) => {
+			let callback = this.remoteFns[callbackId]?.ref.deref()
+
+			if (!callback) {
+				callback = ((...args: any[]) => {
 					const orgError = new Error()
 					return new Promise((resolve, reject) => {
-						const callbackId = a.value
+						const callbackId = a.value[0]
 						this.sendCallback(
 							handle,
 							callbackId,
@@ -117,9 +121,14 @@ export abstract class Worker {
 						)
 					})
 				})
+
+				this.remoteFns[callbackId] = { ref: new WeakRef(callback), count }
+				this.finalizationRegistry.register(callback, callbackId)
+			} else {
+				this.remoteFns[callbackId].count = count
 			}
 
-			return this.remoteFns[callbackId]
+			return callback
 		})
 	}
 	private encodeArgumentsToParent (instance: any, args: any[]): ArgDefinition[] {
@@ -169,6 +178,14 @@ export abstract class Worker {
 			args: args
 		}
 		this.sendInstanceMessageToParent(handle, msg, cb)
+	}
+	private sendCallbackFinalize (handle: ChildHandle, callbackId: string, count: number) {
+		let msg: Message.From.Child.CallbackFinalizeConstr = {
+			cmd: Message.From.Child.CommandType.CALLBACK_FINALIZE,
+			callbackId: callbackId,
+			count
+		}
+		this.sendChildMessageToParent(handle, msg)
 	}
 	private getAllProperties (obj: Object) {
 		let props: Array<string> = []
@@ -404,7 +421,7 @@ export abstract class Worker {
 			let callback = this.callbacks[msg.callbackId]
 			if (callback) {
 				try {
-					Promise.resolve(callback(...msg.args))
+					Promise.resolve(callback.fun(...msg.args))
 					.then((result: any) => {
 						const encodedResult = this.encodeArgumentsToParent(instance, [result])
 						this.replyToInstanceMessage(handle, msg, encodedResult[0])
@@ -452,6 +469,13 @@ export abstract class Worker {
 					}, 100)
 				}
 			}, pingTime)
+		}
+	}
+	private finalizeRemoteFunction (callbackId: string) {
+		const remoteFun = this.remoteFns[callbackId]
+		if (!remoteFun?.ref.deref()) {
+			this.sendCallbackFinalize(this.childHandler, callbackId, remoteFun.count)
+			delete this.remoteFns[callbackId]
 		}
 	}
 }

--- a/src/parent-process/threadedClass.ts
+++ b/src/parent-process/threadedClass.ts
@@ -97,7 +97,7 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 						// Function result function is called from parent
 						sendCallback(
 							instance,
-							a.value,
+							a.value[0],
 							args, (_instance, err, encodedResult) => {
 								// Function result is returned from worker
 								if (err) {
@@ -130,7 +130,7 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 				let callback = instance.child.callbacks[msg.callbackId]
 				if (callback) {
 					try {
-						Promise.resolve(callback(...msg.args))
+						Promise.resolve(callback.fun(...msg.args))
 						.then((result: any) => {
 							let encodedResult = encodeArguments(instance, instance.child.callbacks, [result], !!config.disableMultithreading)
 							sendReplyToInstance(

--- a/src/parent-process/threadedClass.ts
+++ b/src/parent-process/threadedClass.ts
@@ -92,24 +92,35 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 		}
 		function decodeResultFromWorker (instance: ChildInstance, encodedResult: any) {
 			return decodeArguments(() => instance.proxy, [encodedResult], (a: ArgDefinition) => {
-				return (...args: any[]) => {
-					return new Promise((resolve, reject) => {
-						// Function result function is called from parent
-						sendCallback(
-							instance,
-							a.value[0],
-							args, (_instance, err, encodedResult) => {
-								// Function result is returned from worker
-								if (err) {
-									reject(err)
-								} else {
-									let result = decodeResultFromWorker(_instance, encodedResult)
-									resolve(result)
+				const callbackId = a.value[0]
+				const count = a.value[1]
+
+				let callback = instance.child.remoteFns[callbackId]?.ref.deref()
+				if (!callback) {
+					callback = (...args: any[]) => {
+						return new Promise((resolve, reject) => {
+							// Function result function is called from parent
+							sendCallback(
+								instance,
+								callbackId,
+								args, (_instance, err, encodedResult) => {
+									// Function result is returned from worker
+									if (err) {
+										reject(err)
+									} else {
+										let result = decodeResultFromWorker(_instance, encodedResult)
+										resolve(result)
+									}
 								}
-							}
-						)
-					})
+							)
+						})
+					}
+					instance.child.remoteFns[callbackId] = { ref: new WeakRef(callback), count }
+					instance.child.finalizationRegistry.register(callback, callbackId)
+				} else {
+					instance.child.remoteFns[callbackId].count = count
 				}
+				return callback
 			})[0]
 		}
 		function onMessageFromInstance (instance: ChildInstance, m: Message.From.Instance.Any) {
@@ -127,7 +138,7 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 			} else if (m.cmd === Message.From.Instance.CommandType.CALLBACK) {
 				// Callback function is called by worker
 				let msg: Message.From.Instance.Callback = m
-				let callback = instance.child.callbacks[msg.callbackId]
+				let callback = instance.child.callbacks.get(msg.callbackId)
 				if (callback) {
 					try {
 						Promise.resolve(callback.fun(...msg.args))

--- a/src/shared/callbackMap.ts
+++ b/src/shared/callbackMap.ts
@@ -1,0 +1,29 @@
+export interface Callback {
+    readonly id: string
+    fun: Function
+    count: number
+}
+
+export class CallbackMap {
+    private byId = new Map<string, Callback>()
+    private byFun = new Map<Function, Callback>()
+
+	insert(id: string, fun: Function, count: number): void {
+		const callback: Callback = {
+			id,
+			fun,
+			count
+		}
+		this.byFun.set(fun, callback)
+		this.byId.set(id, callback)
+	}
+	get(idOrFun: string | Function): Callback | undefined {
+		return typeof idOrFun === 'function' ? this.byFun.get(idOrFun) : this.byId.get(idOrFun)
+	}
+    delete(idOrFun: string | Function): void {
+        const el = typeof idOrFun === 'function' ? this.byFun.get(idOrFun) : this.byId.get(idOrFun)
+		if (!el) return
+		this.byFun.delete(el.fun)
+		this.byId.delete(el.id)
+    }
+}


### PR DESCRIPTION
This PR solves the known limitation of storing references to callback functions indefinitely.
Thanks to `WeakRef` and `FinalizationRegistry` we are now able to tell when the parent no longer references a callback provided by the child, making it possible to remove the reference on the child side (and vice versa for callbacks provided by the parent to the child).

Changes the minimum required node version to `14.6.0`, and target to `es2021`.

Still a draft because the following are missing:
- [ ] tests