### PR TITLE
feat: allow disabling some timeouts, add error types, and autoRestart retry options

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ An optional options object can be passed to threadedClass() with the following p
 | `threadId` | string | Set to an arbitrary id to put the instance in a specific thread. Instances with the same threadIds will be put in the same thread. |
 | `autoRestart` | boolean | If the process crashes or freezes it's automatically restarted. (ThreadedClassManager will emit the "restarted" event upon restart) |
 | `restartTimeout` | number | (milliseconds), if the process needs to restart, how long to wait for it to initalize, before failing. (default is 1000ms, 0 disables this timeout) |
+| `autoRestartRetryCount` | number | If an autoRestart fails and this is set, ThreadedClass will continue to try to restart the thread. (defaults is 1, 0 means continue to restart indefinitely) |
+| `autoRestartRetryDelay` | number | (milliseconds), how long to wait before retrying to restart the thread after autoRestart fails. (default is 1000 ms) |
 | `killTimeout` | number | (milliseconds), if the process is being killed, how long to wait for it to terminate, before failing. (default is 1000ms, 0 disables this timeout)  |
 | `disableMultithreading` | boolean | Set to true to disable multi-threading, this might be useful when you want to disable multi-threading but keep the interface unchanged. |
 | `pathToWorker` | string | Set path to worker, used in browser |

--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ An optional options object can be passed to threadedClass() with the following p
 | `threadUsage` | number | A number between 0 - 1, how large part of a thread the instance takes up. For example; if set to 0.1, a thread will be re-used for up to 10 instances. |
 | `threadId` | string | Set to an arbitrary id to put the instance in a specific thread. Instances with the same threadIds will be put in the same thread. |
 | `autoRestart` | boolean | If the process crashes or freezes it's automatically restarted. (ThreadedClassManager will emit the "restarted" event upon restart) |
+| `restartTimeout` | number | (milliseconds), if the process needs to restart, how long to wait for it to initalize, before failing. (default is 1000ms, 0 disables this timeout) |
+| `killTimeout` | number | (milliseconds), if the process is being killed, how long to wait for it to terminate, before failing. (default is 1000ms, 0 disables this timeout)  |
 | `disableMultithreading` | boolean | Set to true to disable multi-threading, this might be useful when you want to disable multi-threading but keep the interface unchanged. |
 | `pathToWorker` | string | Set path to worker, used in browser |
-| `freezeLimit` | number | (milliseconds), how long to wait before considering the child to be unresponsive. (default is 1000 ms) |
+| `freezeLimit` | number | (milliseconds), how long to wait before considering the child to be unresponsive. (default is 1000 ms, 0 disables this timeout) |
 
 ## Features
 

--- a/src/__tests__/errorRestart.spec.ts
+++ b/src/__tests__/errorRestart.spec.ts
@@ -10,13 +10,22 @@ import { promises } from 'fs'
 const TESTCLASS_PATH = '../../test-lib/testClassErrors.js'
 
 describe('threadedclass', () => {
-	const TMP_STATE_FILE = join(tmpdir(), 'test_state')
+	const TMP_STATE_FILES: string[] = []
+	let fileCount = 0
+
+	function getStateFile() {
+		const file = join(tmpdir(), 'test_state_' + fileCount++)
+		TMP_STATE_FILES.push(file)
+		return file
+	}
 
 	async function clearTestTempState (): Promise<void> {
-		try {
-			await promises.unlink(TMP_STATE_FILE)
-		} catch {
-			// don't do anything
+		for (const file of TMP_STATE_FILES) {
+			try {
+				await promises.unlink(file)
+			} catch {
+				// don't do anything
+			}
 		}
 	}
 
@@ -35,7 +44,7 @@ describe('threadedclass', () => {
 	test('restart after error', async () => {
 		const RESTART_TIME = 100
 
-		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [], {
+		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [{}], {
 			autoRestart: true,
 			threadUsage: 1
 		})
@@ -101,10 +110,10 @@ describe('threadedclass', () => {
 	test('emit error if constructor crashes on subsequent restart', async () => {
 		const RESTART_TIME = 100
 
-		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [1, TMP_STATE_FILE], {
+		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [{ failInConstructorAfter: 1, counterFile: getStateFile() }], {
 			autoRestart: true,
 			threadUsage: 1,
-			restartTimeout: 100
+			restartTimeout: 200
 		})
 		let onClosed = jest.fn(() => {
 			// oh dear, the process was closed
@@ -151,10 +160,10 @@ describe('threadedclass', () => {
 	test('Manually restart instance', async () => {
 		const KILL_TIMEOUT = 100
 
-		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [0, undefined], {
+		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [{}], {
 			autoRestart: true,
 			threadUsage: 1,
-			restartTimeout: 100,
+			restartTimeout: 200,
 			killTimeout: KILL_TIMEOUT
 		})
 		let onClosed = jest.fn(() => {
@@ -194,6 +203,171 @@ describe('threadedclass', () => {
 
 		expect(onClosed).toHaveBeenCalledTimes(2)
 		expect(onError).toHaveBeenCalledTimes(0)
+
+		try {
+			await ThreadedClassManager.destroy(threaded)
+		} catch (e) {
+			// console.log('Could not close class proxy')
+		}
+	})
+
+	test('emit error if constructor times out on subsequent restart', async () => {
+		const RESTART_TIME = 100
+
+		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [{ busyConstructorAfter: 1, busyConstructorTimeMs: RESTART_TIME+50, counterFile: getStateFile() }], {
+			autoRestart: true,
+			threadUsage: 1,
+			restartTimeout: RESTART_TIME
+		})
+		let onClosed = jest.fn(() => {
+			// oh dear, the process was closed
+		})
+		const onError = jest.fn((_e) => {
+			// we had a global uncaught error
+		})
+		const onRestarted = jest.fn(() => {
+			// the thread was restarted
+		})
+
+		ThreadedClassManager.onEvent(threaded, 'thread_closed', onClosed)
+		ThreadedClassManager.onEvent(threaded, 'error', onError)
+		ThreadedClassManager.onEvent(threaded, 'restarted', onRestarted)
+
+		expect(await threaded.returnValue('test')).toBe('test')
+		await sleep(100)
+		expect(onClosed).toHaveBeenCalledTimes(0)
+		expect(onError).toHaveBeenCalledTimes(0)
+
+		await sleep(RESTART_TIME)
+
+		expect(await threaded.doAsyncError()).toBeDefined()
+
+		await sleep(1000)
+
+		expect(onClosed).toHaveBeenCalledTimes(2)
+		if (process.version.startsWith('v10.')) {
+			// In Node 10, errors in setTimeout are only logged
+			expect(onError).toHaveBeenCalledTimes(1)
+		} else {
+			expect(onError).toHaveBeenCalledTimes(2)
+		}
+		expect(onError.mock.calls[onError.mock.calls.length - 1][0].name).toBe('RestartTimeoutError')
+
+		await sleep(500)
+
+		try {
+			await ThreadedClassManager.destroy(threaded)
+		} catch (e) {
+			// console.log('Could not close class proxy')
+		}
+	})
+
+	test('manually restart instance after timeout in constructor', async () => {
+		const RESTART_TIME = 200
+
+		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [{ busyConstructorAfter: 1, busyConstructorTimeMs: RESTART_TIME+50, counterFile: getStateFile() }], {
+			autoRestart: true,
+			threadUsage: 1,
+			restartTimeout: RESTART_TIME
+		})
+		let onClosed = jest.fn(() => {
+			// oh dear, the process was closed
+		})
+		const onError = jest.fn((_e) => {
+			// we had a global uncaught error
+		})
+		const onRestarted = jest.fn(() => {
+			// the thread was restarted
+		})
+
+		ThreadedClassManager.onEvent(threaded, 'thread_closed', onClosed)
+		ThreadedClassManager.onEvent(threaded, 'error', onError)
+		ThreadedClassManager.onEvent(threaded, 'restarted', onRestarted)
+
+		expect(await threaded.returnValue('test')).toBe('test')
+		await sleep(100)
+		expect(onClosed).toHaveBeenCalledTimes(0)
+		expect(onError).toHaveBeenCalledTimes(0)
+
+		await sleep(RESTART_TIME)
+
+		expect(await threaded.doAsyncError()).toBeDefined()
+
+		await sleep(1000)
+
+		if (process.version.startsWith('v10.')) {
+			// In Node 10, errors in setTimeout are only logged
+			expect(onError).toHaveBeenCalledTimes(1)
+		} else {
+			expect(onError).toHaveBeenCalledTimes(2)
+		}
+
+		await sleep(1000)
+
+		expect(onRestarted).toHaveBeenCalledTimes(0)
+
+		await ThreadedClassManager.restart(threaded)
+		await sleep(RESTART_TIME)
+
+		expect(await threaded.returnValue('test')).toBe('test')
+
+		try {
+			await ThreadedClassManager.destroy(threaded)
+		} catch (e) {
+			// console.log('Could not close class proxy')
+		}
+	})
+	
+	test('manually restart instance after error in constructor', async () => {
+		const RESTART_TIME = 100
+
+		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [{ failInConstructorAfter: 1, counterFile: getStateFile() }], {
+			autoRestart: true,
+			threadUsage: 1,
+			restartTimeout: 200
+		})
+		let onClosed = jest.fn(() => {
+			// oh dear, the process was closed
+		})
+		const onError = jest.fn((_e) => {
+			// we had a global uncaught error
+		})
+		const onRestarted = jest.fn(() => {
+			// the thread was restarted
+		})
+
+		ThreadedClassManager.onEvent(threaded, 'thread_closed', onClosed)
+		ThreadedClassManager.onEvent(threaded, 'error', onError)
+		ThreadedClassManager.onEvent(threaded, 'restarted', onRestarted)
+
+		expect(await threaded.returnValue('test')).toBe('test')
+		await sleep(100)
+		expect(onClosed).toHaveBeenCalledTimes(0)
+		expect(onError).toHaveBeenCalledTimes(0)
+
+		await sleep(RESTART_TIME)
+
+		expect(await threaded.doAsyncError()).toBeDefined()
+
+		await sleep(1000)
+
+		expect(onClosed).toHaveBeenCalledTimes(2)
+		if (process.version.startsWith('v10.')) {
+			// In Node 10, errors in setTimeout are only logged
+			expect(onError).toHaveBeenCalledTimes(1)
+		} else {
+			expect(onError).toHaveBeenCalledTimes(2)
+		}
+		expect(onError.mock.calls[onError.mock.calls.length - 1][0]).toMatch(/Error in constructor/)
+
+		await sleep(500)
+
+		expect(onRestarted).toHaveBeenCalledTimes(0)
+
+		await ThreadedClassManager.restart(threaded)
+		await sleep(RESTART_TIME)
+
+		expect(await threaded.returnValue('test')).toBe('test')
 
 		try {
 			await ThreadedClassManager.destroy(threaded)

--- a/src/__tests__/errorRestart.spec.ts
+++ b/src/__tests__/errorRestart.spec.ts
@@ -13,7 +13,7 @@ describe('threadedclass', () => {
 	const TMP_STATE_FILES: string[] = []
 	let fileCount = 0
 
-	function getStateFile() {
+	function getStateFile () {
 		const file = join(tmpdir(), 'test_state_' + fileCount++)
 		TMP_STATE_FILES.push(file)
 		return file
@@ -216,7 +216,7 @@ describe('threadedclass', () => {
 
 		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [{
 			busyConstructorAfter: 1,
-			busyConstructorTimeMs: RESTART_TIME+50,
+			busyConstructorTimeMs: RESTART_TIME + 50,
 			counterFile: getStateFile()
 		}], {
 			autoRestart: true,
@@ -265,7 +265,7 @@ describe('threadedclass', () => {
 			// console.log('Could not close class proxy')
 		}
 	})
-	
+
 	test('0 disables restartTimeout', async () => {
 		const RESTART_TIME = 1500
 
@@ -276,7 +276,8 @@ describe('threadedclass', () => {
 		}], {
 			autoRestart: true,
 			threadUsage: 1,
-			restartTimeout: 0
+			restartTimeout: 0,
+			freezeLimit: RESTART_TIME + 1000
 		})
 		let onClosed = jest.fn(() => {
 			// oh dear, the process was closed
@@ -299,9 +300,9 @@ describe('threadedclass', () => {
 
 		expect(await threaded.doAsyncError()).toBeDefined()
 
-		await sleep(RESTART_TIME+500)
+		await sleep(RESTART_TIME + 1000)
 
-		expect(onClosed).toHaveBeenCalledTimes(0)
+		expect(onClosed).toHaveBeenCalledTimes(1)
 		if (process.version.startsWith('v10.')) {
 			// In Node 10, errors in setTimeout are only logged
 			expect(onError).toHaveBeenCalledTimes(0)
@@ -325,7 +326,7 @@ describe('threadedclass', () => {
 		let threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [{
 			busyConstructorAfter: 1,
 			busyConstructorTimeMs:
-			RESTART_TIME+50,
+			RESTART_TIME + 50,
 			counterFile: getStateFile()
 		}], {
 			autoRestart: true,
@@ -379,7 +380,7 @@ describe('threadedclass', () => {
 			// console.log('Could not close class proxy')
 		}
 	})
-	
+
 	test('manually restart instance after error in constructor', async () => {
 		const RESTART_TIME = 100
 

--- a/src/__tests__/errors.spec.ts
+++ b/src/__tests__/errors.spec.ts
@@ -22,7 +22,7 @@ const getTests = (disableMultithreading: boolean) => {
 			ThreadedClassManager.handleExit = RegisterExitHandlers.NO
 			ThreadedClassManager.debug = false
 
-			threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [], { disableMultithreading })
+			threaded = await threadedClass<TestClassErrors, typeof TestClassErrors>(TESTCLASS_PATH, 'TestClassErrors', [{}], { disableMultithreading })
 			onClosedListener = ThreadedClassManager.onEvent(threaded, 'thread_closed', onClosed)
 			onErrorListener = ThreadedClassManager.onEvent(threaded, 'error', onError)
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -31,6 +31,10 @@ export interface ThreadedClassConfig {
 	autoRestart?: boolean
 	/** If the process needs to restart, how long to wait for it to initalize, before failing. (default is 1000ms, 0 disables this timeout) */
 	restartTimeout?: number
+	/** If an autoRestart fails and this is set, ThreadedClass will continue to try to restart the thread. (defaults is 1, 0 means continue to restart indefinitely) */
+	autoRestartRetryCount?: number
+	/** (milliseconds), how long to wait before retrying to restart the thread. (default is 1000 ms) */
+	autoRestartRetryDelay?: number
 	/** If the process is being killed, how long to wait for it to terminate, before failing. (default is 1000ms, 0 disables this timeout) */
 	killTimeout?: number
 	/** Set to true to disable multi-threading, this might be useful when you want to disable multi-threading but keep the interface unchanged. */

--- a/src/api.ts
+++ b/src/api.ts
@@ -29,15 +29,15 @@ export interface ThreadedClassConfig {
 	threadId?: string
 	/** If the process crashes or freezes it's automatically restarted. (ThreadedClassManager will emit the "restarted" event upon restart) */
 	autoRestart?: boolean
-	/** If the process needs to restart, how long to wait for it to initalize, before failing. (default is 1000ms) */
+	/** If the process needs to restart, how long to wait for it to initalize, before failing. (default is 1000ms, 0 disables this timeout) */
 	restartTimeout?: number
-	/** If the process is being killed, how long to wait for it to terminate, before failing. (default is 1000ms) */
+	/** If the process is being killed, how long to wait for it to terminate, before failing. (default is 1000ms, 0 disables this timeout) */
 	killTimeout?: number
 	/** Set to true to disable multi-threading, this might be useful when you want to disable multi-threading but keep the interface unchanged. */
 	disableMultithreading?: boolean
 	/** Set path to worker, used in browser */
 	pathToWorker?: string
-	/** (milliseconds), how long to wait before considering the child to be unresponsive. (default is 1000 ms) */
+	/** (milliseconds), how long to wait before considering the child to be unresponsive. (default is 1000 ms, 0 disables this timeout) */
 	freezeLimit?: number
 	/** Optional: name of the instance, used in debugging */
 	instanceName?: string
@@ -51,3 +51,6 @@ export interface WebWorkerMemoryUsage {
 export type MemUsageReportInner = NodeJS.MemoryUsage | WebWorkerMemoryUsage | { error: string }
 
 export type MemUsageReport = MemUsageReportInner & { description: string }
+
+export class RestartTimeoutError extends Error { name = 'RestartTimeoutError' }
+export class KillTimeoutError extends Error { name = 'KillTimeoutError' }

--- a/src/parent-process/manager.ts
+++ b/src/parent-process/manager.ts
@@ -447,7 +447,7 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 				const restartTimeout = child.config.restartTimeout ?? DEFAULT_RESTART_TIMEOUT
 				timeout = setTimeout(() => {
 					reject(new RestartTimeoutError(`Timeout when trying to restart after ${restartTimeout}`))
-					this.killChild(child, 'timeout when restarting').catch((e) => {
+					this.killChild(child, 'timeout when restarting', true).catch((e) => {
 						this.consoleError(`Could not kill child: "${child.id}"`, e)
 					})
 					this.removeListener('initialized', onInit)
@@ -465,7 +465,8 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 			}
 			this.on('initialized', onInit)
 		})
-		const promises: Array<Promise<void>> = []
+
+		const promises: Array<Promise<void>> = [p]
 
 		let instances: ChildInstance[] = (
 			onlyInstances ||
@@ -480,7 +481,7 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 					this.sendInit(child, instance, instance.config, (_instance: ChildInstance, err: Error | null) => {
 						// no need to do anything, the proxy is already initialized from earlier
 						if (err) {
-							this.killChild(child, 'error on init').catch((e) => {
+							this.killChild(child, 'error on init', true).catch((e) => {
 								this.consoleError(`Could not kill child: "${child.id}"`, e)
 							})
 							reject(err)
@@ -494,8 +495,6 @@ export class ThreadedClassManagerClassInternal extends EventEmitter {
 		})
 
 		await Promise.all(promises)
-
-		await p
 	}
 	public sendInit (
 		child: Child,

--- a/src/shared/sharedApi.ts
+++ b/src/shared/sharedApi.ts
@@ -5,6 +5,8 @@ import { ThreadedClassConfig } from '../api'
 export const DEFAULT_CHILD_FREEZE_TIME = 1000 // how long to wait before considering a child to be unresponsive
 export const DEFAULT_RESTART_TIMEOUT = 1000 // how long to wait for the child to come back after restart
 export const DEFAULT_KILL_TIMEOUT = 1000 // how long to wait for the thread to close when terminating it
+export const DEFAULT_AUTO_RESTART_RETRY_COUNT = 1 // after how many failed restarts to give up
+export const DEFAULT_AUTO_RESTART_RETRY_DELAY = 1000 // how long to wait before retrying a failed restart
 
 export type InitProps = Array<InitProp>
 export enum InitPropType {

--- a/test-lib/testClassErrors.js
+++ b/test-lib/testClassErrors.js
@@ -5,7 +5,8 @@ const tslib_1 = require("tslib");
 const events_1 = require("events");
 const fs_1 = require("fs");
 class TestClassErrors extends events_1.EventEmitter {
-    constructor(failInConstructorAfter, counterFile) {
+    constructor(options) {
+        var _a;
         super();
         this.lastAsyncError = null;
         this.unhandledPromiseRejections = [];
@@ -13,18 +14,26 @@ class TestClassErrors extends events_1.EventEmitter {
         process.on('unhandledRejection', (message) => {
             this.unhandledPromiseRejections.push(`${message}` + (typeof message === 'object' ? message.stack : ''));
         });
-        if (failInConstructorAfter && counterFile) {
+        if (options.counterFile) {
             let state = '0';
             try {
-                state = (0, fs_1.readFileSync)(counterFile, {
+                state = (0, fs_1.readFileSync)(options.counterFile, {
                     encoding: 'utf8'
                 });
             }
             catch (_err) {
                 // ignore
             }
-            (0, fs_1.writeFileSync)(counterFile, String(Number.parseInt(state, 10) + 1));
-            if (state === String(failInConstructorAfter)) {
+            (0, fs_1.writeFileSync)(options.counterFile, String(Number.parseInt(state, 10) + 1));
+            if (options.busyConstructorAfter && state === String(options.busyConstructorAfter)) {
+                const start = Date.now();
+                let i = 0;
+                while (Date.now() < start + ((_a = options.busyConstructorTimeMs) !== null && _a !== void 0 ? _a : 200)) {
+                    i++;
+                }
+                console.log(i);
+            }
+            if (options.failInConstructorAfter && state === String(options.failInConstructorAfter)) {
                 throw new Error('Error in constructor');
             }
         }

--- a/test-lib/testClassErrors.js
+++ b/test-lib/testClassErrors.js
@@ -6,7 +6,7 @@ const events_1 = require("events");
 const fs_1 = require("fs");
 class TestClassErrors extends events_1.EventEmitter {
     constructor(options) {
-        var _a;
+        var _a, _b;
         super();
         this.lastAsyncError = null;
         this.unhandledPromiseRejections = [];
@@ -15,25 +15,25 @@ class TestClassErrors extends events_1.EventEmitter {
             this.unhandledPromiseRejections.push(`${message}` + (typeof message === 'object' ? message.stack : ''));
         });
         if (options.counterFile) {
-            let state = '0';
+            let state = 0;
             try {
-                state = (0, fs_1.readFileSync)(options.counterFile, {
+                state = Number.parseInt((0, fs_1.readFileSync)(options.counterFile, {
                     encoding: 'utf8'
-                });
+                }), 10);
             }
             catch (_err) {
                 // ignore
             }
-            (0, fs_1.writeFileSync)(options.counterFile, String(Number.parseInt(state, 10) + 1));
-            if (options.busyConstructorAfter && state === String(options.busyConstructorAfter)) {
+            (0, fs_1.writeFileSync)(options.counterFile, String(state + 1));
+            if (options.busyConstructorAfter && state >= options.busyConstructorAfter && state < options.busyConstructorAfter + ((_a = options.busyConstructorCount) !== null && _a !== void 0 ? _a : 1)) {
                 const start = Date.now();
                 let i = 0;
-                while (Date.now() < start + ((_a = options.busyConstructorTimeMs) !== null && _a !== void 0 ? _a : 200)) {
+                while (Date.now() < start + ((_b = options.busyConstructorTimeMs) !== null && _b !== void 0 ? _b : 200)) {
                     i++;
                 }
                 console.log(i);
             }
-            if (options.failInConstructorAfter && state === String(options.failInConstructorAfter)) {
+            if (options.failInConstructorAfter && state === options.failInConstructorAfter) {
                 throw new Error('Error in constructor');
             }
         }

--- a/test-lib/testClassErrors.ts
+++ b/test-lib/testClassErrors.ts
@@ -6,7 +6,13 @@ export class TestClassErrors extends EventEmitter {
 	private lastAsyncError: Error | null = null
 	private unhandledPromiseRejections: string[] = []
 
-	constructor (options: {failInConstructorAfter?: number, busyConstructorAfter?: number, busyConstructorTimeMs?: number, counterFile?: string}) {
+	constructor (options: {
+		failInConstructorAfter?: number,
+		busyConstructorAfter?: number,
+		busyConstructorTimeMs?: number,
+		busyConstructorCount?: number,
+		counterFile?: string
+	}) {
 		super()
 
 		// Catch unhandled promises:
@@ -15,17 +21,17 @@ export class TestClassErrors extends EventEmitter {
 		})
 
 		if (options.counterFile) {
-			let state = '0'
+			let state = 0
 			try {
-				state = readFileSync(options.counterFile, {
+				state = Number.parseInt(readFileSync(options.counterFile, {
 					encoding: 'utf8'
-				})
+				}), 10)
 			} catch (_err) {
 				// ignore
 			}
-			writeFileSync(options.counterFile, String(Number.parseInt(state, 10) + 1))
+			writeFileSync(options.counterFile, String(state + 1))
 
-			if (options.busyConstructorAfter && state === String(options.busyConstructorAfter)) {
+			if (options.busyConstructorAfter && state >= options.busyConstructorAfter && state < options.busyConstructorAfter + (options.busyConstructorCount ?? 1)) {
 				const start = Date.now()
 				let i = 0
 				while (Date.now() < start + (options.busyConstructorTimeMs ?? 200)) {
@@ -34,7 +40,7 @@ export class TestClassErrors extends EventEmitter {
 				console.log(i)
 			}
 
-			if (options.failInConstructorAfter && state === String(options.failInConstructorAfter)) {
+			if (options.failInConstructorAfter && state === options.failInConstructorAfter) {
 				throw new Error('Error in constructor')
 			}
 		}

--- a/test-lib/testClassErrors.ts
+++ b/test-lib/testClassErrors.ts
@@ -6,7 +6,7 @@ export class TestClassErrors extends EventEmitter {
 	private lastAsyncError: Error | null = null
 	private unhandledPromiseRejections: string[] = []
 
-	constructor (failInConstructorAfter?: number, counterFile?: string) {
+	constructor (options: {failInConstructorAfter?: number, busyConstructorAfter?: number, busyConstructorTimeMs?: number, counterFile?: string}) {
 		super()
 
 		// Catch unhandled promises:
@@ -14,18 +14,27 @@ export class TestClassErrors extends EventEmitter {
 			this.unhandledPromiseRejections.push(`${message}` + (typeof message === 'object' ? (message as any).stack : ''))
 		})
 
-		if (failInConstructorAfter && counterFile) {
+		if (options.counterFile) {
 			let state = '0'
 			try {
-				state = readFileSync(counterFile, {
+				state = readFileSync(options.counterFile, {
 					encoding: 'utf8'
 				})
 			} catch (_err) {
 				// ignore
 			}
-			writeFileSync(counterFile, String(Number.parseInt(state, 10) + 1))
+			writeFileSync(options.counterFile, String(Number.parseInt(state, 10) + 1))
 
-			if (state === String(failInConstructorAfter)) {
+			if (options.busyConstructorAfter && state === String(options.busyConstructorAfter)) {
+				const start = Date.now()
+				let i = 0
+				while (Date.now() < start + (options.busyConstructorTimeMs ?? 200)) {
+					i++
+				}
+				console.log(i)
+			}
+
+			if (options.failInConstructorAfter && state === String(options.failInConstructorAfter)) {
 				throw new Error('Error in constructor')
 			}
 		}


### PR DESCRIPTION
Allows disabling some timeouts by setting their respective options to `0`.
Adds new error types for some timeouts, to allow appropriate handling by the users.
~~No longer cleans up the instance in case of an error or timeout when restarting, allowing for a manual restart afterwards.~~
Adds previously undocumented options to README.md.

**New changes after the pair-programming session:**
Enables making more than one autoRestart atempts in case it fails (timeout/crash), via two new options:
- `autoRestartRetryCount`, indicating how many attempts to auto restart the child are allowed.
- `autoRestartRetryDelay`, if an autoRestart fails, indicates how long to wait after a failed autoRestart before making another attempt.

If `autoRestartRetryCount !== 1`, a warning will be emitted after each failed autoRestart attempt.