### PR TITLE
fix: don't reply with an error if the child is not available anymore

### DIFF
--- a/src/__tests__/edgecases.spec.ts
+++ b/src/__tests__/edgecases.spec.ts
@@ -1,0 +1,79 @@
+import {
+	RegisterExitHandlers,
+	threadedClass,
+	ThreadedClassManager
+} from '../index'
+import { TestClassEdgeCases } from '../../test-lib/testClassEdgeCases'
+import { ThreadedClassManagerInternal } from '../parent-process/manager'
+const TESTCLASS_PATH = '../../test-lib/testClassEdgeCases.js'
+
+describe('edgeCases', () => {
+	const onManagerDebugLogError = jest.fn()
+
+	beforeAll(async () => {
+		ThreadedClassManager.debug = false
+		ThreadedClassManager.handleExit = RegisterExitHandlers.NO
+
+		ThreadedClassManagerInternal.debugLogError = onManagerDebugLogError
+	})
+	beforeEach(async () => {
+		await ThreadedClassManager.destroyAll()
+	})
+	afterEach(async () => {
+		await ThreadedClassManager.destroyAll()
+		expect(onManagerDebugLogError).toHaveBeenCalledTimes(0)
+	})
+	afterAll(async () => {
+		onManagerDebugLogError.mockRestore()
+	})
+
+	test('Child calls callback, then dies', async () => {
+		// * Parent calls a child method
+		// * In the child method, Child calls a callback
+		// * Child dies while the callback is executing
+		// * The callback throws an error
+		// Test:
+		// * Ensure that we don't crash completely
+		// * The call to child method throws an error due to the child closing
+		// * A debug log is made to log the issue of being unable to return the thrown error in the callback to the child.
+
+		const threaded = await threadedClass<TestClassEdgeCases, typeof TestClassEdgeCases>(TESTCLASS_PATH, 'TestClassEdgeCases', [], {})
+
+		const onDestroyError = jest.fn((e) => {
+			console.error('onDestroyError', e)
+		})
+		const onAfterDestroy = jest.fn()
+		const onCallbackError = jest.fn()
+
+		const callback = jest.fn(async () => {
+
+			// Before this callback finishes, the child will die:
+			await ThreadedClassManager.destroy(threaded).catch(onDestroyError)
+
+			onAfterDestroy()
+
+			// Now the child is dead, we throw from this callback.
+			throw new Error('Here is the callback error')
+		})
+
+		await threaded.callCallback(callback).catch(onCallbackError)
+
+		await sleep(10) // Ensure that all promises and callbacks have been resolved
+
+		expect(callback).toHaveBeenCalledTimes(1)
+		expect(onDestroyError).toHaveBeenCalledTimes(0)
+		expect(onAfterDestroy).toHaveBeenCalledTimes(1)
+		expect(onCallbackError).toHaveBeenCalledTimes(1)
+		expect(onCallbackError.mock.calls[0][0].toString()).toMatch(/method.*aborted due to.*child.*closed/i)
+
+		expect(onManagerDebugLogError).toHaveBeenCalledTimes(1)
+		expect(onManagerDebugLogError.mock.calls[0][0].toString()).toMatch(/thrown error in callback.*unable to forward error.*due to.*process of instance.*has been closed/i)
+
+		onManagerDebugLogError.mockClear()
+
+	})
+}
+)
+function sleep (ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/src/parent-process/manager.ts
+++ b/src/parent-process/manager.ts
@@ -1059,7 +1059,7 @@ ${getStack()}`)
 		})
 		child.methods = {}
 	}
-	/** trace to console.error if debugging is enabled*/
+	/** trace to console.error if debugging is enabled */
 	public debugLogError (...args: any[]) {
 		if (this.debug) this.consoleError(...args)
 

--- a/src/parent-process/manager.ts
+++ b/src/parent-process/manager.ts
@@ -930,42 +930,7 @@ ${getStack()}`)
 				cb(null, msg.reply)
 			}
 			delete child.instanceMessageQueue[msg.replyTo + '']
-		} else if (message.cmd === Message.From.Child.CommandType.CALLBACK) {
-			// Callback function is called by worker
-			let msg: Message.From.Child.Callback = message
-			let callback = child.callbacks[msg.callbackId]
-			if (callback) {
-				try {
-					Promise.resolve(callback(...msg.args))
-					.then((result: any) => {
-						let encodedResult = encodeArguments({}, child.callbacks, [result], !!child.process.isFakeProcess)
-						this._sendReplyToChild(
-							child,
-							msg.cmdId,
-							undefined,
-							encodedResult[0]
-						)
-					})
-					.catch((err: Error) => {
-						this._replyErrorToChild(child, msg, err)
-					})
-				} catch (err) {
-					this._replyErrorToChild(child, msg, err)
-				}
-			} else throw Error(`callback "${msg.callbackId}" not found in child ${child.id}`)
 		}
-	}
-	private _replyErrorToChild (child: Child, messageToReplyTo: Message.From.Child.Callback, error: Error) {
-		this._sendReplyToChild(child, messageToReplyTo.cmdId, error)
-	}
-	private _sendReplyToChild (child: Child, replyTo: number, error?: Error, reply?: any, cb?: CallbackFunction) {
-		let msg: Message.To.Child.ReplyConstr = {
-			cmd: Message.To.Child.CommandType.REPLY,
-			replyTo: replyTo,
-			reply: reply,
-			error: error ? (error.stack || error).toString() : error
-		}
-		this.sendMessageToChild(child, msg, cb)
 	}
 	private _findFreeChild (threadUsage: number): Child | null {
 		let id = Object.keys(this._children).find((id) => {

--- a/src/parent-process/threadedClass.ts
+++ b/src/parent-process/threadedClass.ts
@@ -144,7 +144,6 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 							)
 						})
 						.catch((err: Error) => {
-							// Don't reply if there's no one to receive the answer
 							try {
 								replyError(instance, msg, err)
 							} catch (e) {
@@ -152,7 +151,6 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 							}
 						})
 					} catch (err) {
-						// Don't reply if there's no one to receive the answer
 						try {
 							replyError(instance, msg, err)
 						} catch (e) {

--- a/src/parent-process/threadedClass.ts
+++ b/src/parent-process/threadedClass.ts
@@ -144,14 +144,20 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 							)
 						})
 						.catch((err: Error) => {
-							// Don't reply if there's nooone to receive the answer
-							if (!instance.child.alive || instance.child.isClosing) return
-							replyError(instance, msg, err)
+							// Don't reply if there's no one to receive the answer
+							try {
+								replyError(instance, msg, err)
+							} catch (e) {
+								ThreadedClassManagerInternal.debugLogError(new Error(`ThreadedClass: Thrown error in callback "${msg.callbackId}": Unable to forward error to child due to: ${e}`))
+							}
 						})
 					} catch (err) {
-						// Don't reply if there's nooone to receive the answer
-						if (!instance.child.alive || instance.child.isClosing) return
-						replyError(instance, msg, err)
+						// Don't reply if there's no one to receive the answer
+						try {
+							replyError(instance, msg, err)
+						} catch (e) {
+							ThreadedClassManagerInternal.debugLogError(new Error(`ThreadedClass: Thrown error in callback "${msg.callbackId}": Unable to forward error to child due to: ${e}`))
+						}
 					}
 				} else throw Error(`callback "${msg.callbackId}" not found in instance ${m.instanceId}`)
 			}

--- a/src/parent-process/threadedClass.ts
+++ b/src/parent-process/threadedClass.ts
@@ -144,9 +144,13 @@ export function threadedClass<T, TCtor extends new (...args: any) => T> (
 							)
 						})
 						.catch((err: Error) => {
+							// Don't reply if there's nooone to receive the answer
+							if (!instance.child.alive || instance.child.isClosing) return
 							replyError(instance, msg, err)
 						})
 					} catch (err) {
+						// Don't reply if there's nooone to receive the answer
+						if (!instance.child.alive || instance.child.isClosing) return
 						replyError(instance, msg, err)
 					}
 				} else throw Error(`callback "${msg.callbackId}" not found in instance ${m.instanceId}`)

--- a/src/shared/sharedApi.ts
+++ b/src/shared/sharedApi.ts
@@ -209,7 +209,6 @@ export namespace Message {
 			export enum CommandType {
 				LOG = 'log',
 				REPLY = 'reply',
-				CALLBACK = 'callback'
 			}
 
 			export interface LogConstr {
@@ -226,15 +225,8 @@ export namespace Message {
 			}
 			export type Reply = ReplyConstr & ChildBase
 
-			export interface CallbackConstr {
-				cmd: CommandType.CALLBACK
-				callbackId: string
-				args: Array<any>
-			}
-			export type Callback = CallbackConstr & ChildBase
-
-			export type AnyConstr 	= ReplyConstr 	| CallbackConstr 	| LogConstr
-			export type Any 		= Reply			| Callback			| Log
+			export type AnyConstr 	= ReplyConstr  	| LogConstr
+			export type Any 		= Reply			| Log
 		}
 	}
 }

--- a/src/shared/sharedApi.ts
+++ b/src/shared/sharedApi.ts
@@ -208,7 +208,7 @@ export namespace Message {
 		export namespace Child {
 			export enum CommandType {
 				LOG = 'log',
-				REPLY = 'reply',
+				REPLY = 'reply'
 			}
 
 			export interface LogConstr {

--- a/test-lib/testClassEdgeCases.js
+++ b/test-lib/testClassEdgeCases.js
@@ -1,0 +1,28 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.TestClassEdgeCases = void 0;
+const tslib_1 = require("tslib");
+const events_1 = require("events");
+class TestClassEdgeCases extends events_1.EventEmitter {
+    constructor() {
+        super();
+        this.unhandledPromiseRejections = [];
+        // Catch unhandled promises:
+        process.on('unhandledRejection', (message) => {
+            this.unhandledPromiseRejections.push(`${message}` + (typeof message === 'object' ? message.stack : ''));
+        });
+    }
+    getUnhandledPromiseRejections() {
+        return this.unhandledPromiseRejections;
+    }
+    clearUnhandledPromiseRejections() {
+        this.unhandledPromiseRejections = [];
+    }
+    callCallback(cb) {
+        return (0, tslib_1.__awaiter)(this, void 0, void 0, function* () {
+            const value = yield cb();
+            return value;
+        });
+    }
+}
+exports.TestClassEdgeCases = TestClassEdgeCases;

--- a/test-lib/testClassEdgeCases.ts
+++ b/test-lib/testClassEdgeCases.ts
@@ -1,0 +1,28 @@
+import { EventEmitter } from 'events'
+
+export class TestClassEdgeCases extends EventEmitter {
+
+	private unhandledPromiseRejections: string[] = []
+
+	constructor () {
+		super()
+
+		// Catch unhandled promises:
+		process.on('unhandledRejection', (message) => {
+			this.unhandledPromiseRejections.push(`${message}` + (typeof message === 'object' ? (message as any).stack : ''))
+		})
+	}
+
+	public getUnhandledPromiseRejections (): string[] {
+		return this.unhandledPromiseRejections
+	}
+	public clearUnhandledPromiseRejections (): void {
+		this.unhandledPromiseRejections = []
+	}
+
+	public async callCallback (cb: () => Promise<any>): Promise<any> {
+		const value = await cb()
+		return value
+	}
+
+}


### PR DESCRIPTION
Sometimes, `onMessageFromInstance` can be called when the child instance is terminating or already terminated. Also, if the Command is a `CALLBACK`, the callback can take some time to evaluate or crash, at which time sending the `replyError` will cause an irrecoverable crash, similar to:

```
unhandledRejection: Child process of instance instance_7736_0_IpcJobWorker is closing
Error: Child process of instance instance_7736_0_IpcJobWorker is closing
     at ThreadedClassManagerClassInternal.sendMessageToInstance (C:\Projekty\NRK-Automation\tv-automation-server-core.worktrees\release51\meteor\node_modules\threadedclass\dist\parent-process\manager.js:240:23)
     at sendReplyToInstance (C:\Projekty\NRK-Automation\tv-automation-server-core.worktrees\release51\meteor\node_modules\threadedclass\dist\parent-process\threadedClass.js:60:52)
     at replyError (C:\Projekty\NRK-Automation\tv-automation-server-core.worktrees\release51\meteor\node_modules\threadedclass\dist\parent-process\threadedClass.js:63:13)
     at C:\Projekty\NRK-Automation\tv-automation-server-core.worktrees\release51\meteor\node_modules\threadedclass\dist\parent-process\threadedClass.js:119:29
     at C:\Users\Jan Starzak\AppData\Local\.meteor\packages\promise\0.12.2\npm\node_modules\meteor-promise\fiber_pool.js:43:40
```

This modification adds a check to see if the instance is still alive before trying to send a reply.